### PR TITLE
Compile the documentation and publish its API reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
           SUFFIX: ${{ inputs.suffix }}
+          PRERELEASE: ${{ inputs.suffix != '' }}
         run: |
           if [[ -n "$SUFFIX" ]]; then TAG="v$VERSION-$SUFFIX"; else TAG="v$VERSION"; fi
           gh release create "$TAG" \
+            --prerelease="$PRERELEASE" \
             --target "$GITHUB_SHA" \
             --title "$TAG" \
-            --generate-notes
+            --generate-notes \
+            --draft

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,4 +43,42 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew --no-daemon --stacktrace publish
+          ./gradlew --no-daemon --stacktrace \
+            publish
+
+  publish-docs:
+    name: Publish API Reference
+    needs: [validation]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v6
+        name: Checkout Repository
+
+      - uses: ./.github/actions/setup-prerequisites
+        name: Setup Prerequisites
+        with:
+          java-version: 21
+
+      - shell: bash
+        name: Build API Reference
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            dokkaGenerate
+
+      - uses: actions/upload-pages-artifact@v5
+        name: Upload API Reference
+        with:
+          path: build/dokka/html
+
+      - uses: actions/deploy-pages@v5
+        name: Deploy to GitHub Pages
+        id: deployment

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -50,6 +50,15 @@ jobs:
           xvfb-run --auto-servernum ./gradlew --no-daemon --stacktrace --continue \
             build checkKotlinAbi
 
+      # The API reference is not part of `check`, so nothing above would notice if it stopped
+      # rendering. Build the aggregated site so a change that breaks it fails here rather than at
+      # release time. It needs no display.
+      - shell: bash
+        name: Build API Reference
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            dokkaGenerate
+
       # Sanity-check that the publishing configuration resolves and produces artifacts.
       - shell: bash
         name: Publish Dry Run

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -21,6 +21,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/samples" />
+            <option value="$PROJECT_DIR$/samples/docs" />
             <option value="$PROJECT_DIR$/samples/todo-app" />
             <option value="$PROJECT_DIR$/samples/widgets-gallery" />
             <option value="$PROJECT_DIR$/swing-ui" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ the quality gates every change must pass, and the code style.
 # Run a sample application
 ./gradlew :samples:todo-app:run
 ./gradlew :samples:widgets-gallery:run
+
+# API reference for every published module, one site at build/dokka/html
+./gradlew :dokkaGenerate
 ```
 
 Compiling a module also writes the Compose compiler's reports - which composables are skippable, and
@@ -72,7 +75,8 @@ See [`docs/TESTING-COMPONENTS.md`](docs/TESTING-COMPONENTS.md) for the harness g
 `build` runs every module's `check` - compilation, ktlint, detekt, the Compose lint checks, tests,
 the coverage gates and `checkKotlinAbi` - plus `assemble`. Which of those a module carries depends on
 the convention plugins it applies: the vendored `swing-ui-animation` fork is exempt from ktlint,
-detekt and the lint checks. One gate sits outside `build`: `buildSrc` is an included build the
+detekt and the lint checks, and `samples/docs`, which holds generated code, carries none of them
+beyond compilation. One gate sits outside `build`: `buildSrc` is an included build the
 root-level tasks do not reach. So the full gate is two commands, and they are what to run locally
 before pushing:
 
@@ -116,6 +120,28 @@ Piece by piece:
   new behavior you can reach through the test harness. The floors are held, not chased: if a branch is
   a defensive guard with no reachable behavior, leave it uncovered rather than writing a test that
   asserts nothing.
+
+## Documentation snippets
+
+Kotlin snippets in `README.md` and `docs/` are compiled by the build, and marking one is opt-in:
+write `<!--- KNIT example-<document>-01.kt -->` on its own line after the closing fence, and Knit
+merges the block into a file under `samples/docs/build/generated/knit/example/`, taking the number
+from the document's own sequence. A snippet that is a fragment rather than a whole file gets its
+imports and its enclosing function from an `INCLUDE`/`SUFFIX` preamble at the top of the document,
+matched against the example file name; an unmarked block is followed by `<!--- CLEAR -->` so it does
+not merge into the next marked one.
+
+The generated files are a build output, not source: nothing under that directory is committed, and
+there is nothing to regenerate by hand. `build` writes them and compiles them, so a snippet that
+does not compile fails the build. While editing a document, the quick check is:
+
+```bash
+./gradlew :samples:docs:compileKotlin
+```
+
+Renaming or deleting a marked snippet leaves the file it used to generate behind in the build
+directory, where it keeps compiling. Run `./gradlew :samples:docs:clean` after such a change to get
+the same result a fresh checkout gets.
 
 ## Code style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,9 @@ the quality gates every change must pass, and the code style.
 ./gradlew :swing-ui:test
 ./gradlew :swing-ui:test --tests '*ComboBoxEditableTest*'
 
+# The tests that need the window system to itself (focus, minimization)
+./gradlew :swing-ui:exclusiveWindowSystemTest
+
 # Run a sample application
 ./gradlew :samples:todo-app:run
 ./gradlew :samples:widgets-gallery:run
@@ -35,6 +38,14 @@ incremental compiler recompiles only the sources a change touches, and the repor
 increment - a short or empty report means little was recompiled, not that the module has nothing
 unstable. Only a non-incremental compile produces a report covering the whole module:
 `./gradlew --rerun-tasks :swing-ui:compileKotlin`, or clean the module first.
+
+`:swing-ui` splits its suite across two tasks, and `check` runs both. `test` holds everything that
+asserts nothing about which window the window system is attending to, and runs it across parallel
+JVMs; `exclusiveWindowSystemTest` holds the classes tagged `ExclusiveWindowSystem` - those asserting
+on focus or minimization - and runs them one at a time, because two of them at once take that state
+from each other and skip. Write a new test into whichever it belongs to by tagging the class, not by
+where the file sits. Note that a scoped `:swing-ui:test` run also pulls in
+`exclusiveWindowSystemTest`, which the coverage report that follows a test run depends on.
 
 Scope a run while iterating; `./gradlew test` runs every module's suite. The modules test each other:
 `:swing-ui-test` publishes the harness that `:swing-ui`'s own tests are written against, so a harness

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,23 +42,28 @@ change is exercised far more by the library's suite than by the harness's own, a
 sit downstream of the two. A scoped run belongs to the edit loop; the gate below is what a change is
 judged by.
 
-Tests are deterministic and never sleep. Harness-driven tests never attach their root to a window,
-so they run with or without a display. A test that realizes a real top-level peer gates itself with
+Harness-driven tests are deterministic, never sleep, and never attach their root to a window, so
+they run with or without a display. Only a wait on something the composition does not drive - the
+window system, or a quiet period that proves nothing happened - polls against a real deadline. A test
+that realizes a real top-level peer gates itself with
 `assumeFalse(GraphicsEnvironment.isHeadless(), ...)` so it reports skipped without one, and others
-gate the same way on a capability the environment may withhold. A run with no failures is therefore
-not necessarily a complete one: the ignored count in `<module>/build/reports/tests/test/index.html`
-says what did not run. CI runs under a virtual framebuffer, so the display-gated tests skipped here
-run and are judged there too; only the ones gated on a capability the framebuffer itself lacks (see
-Quality gates below) still report skipped in CI.
+gate the same way on a capability the environment may withhold. A run with no
+failures is therefore not necessarily a complete one: the ignored count in
+`<module>/build/reports/tests/test/index.html` says what did not run. CI runs under a virtual
+framebuffer, so the display-gated tests skipped here run and are judged there too; only the ones
+gated on a capability the framebuffer itself lacks (see Quality gates below) still report skipped in
+CI.
 
 See [`docs/TESTING-COMPONENTS.md`](docs/TESTING-COMPONENTS.md) for the harness guide.
 
 ## Quality gates (all must pass)
 
 `build` runs every module's `check` - compilation, ktlint, detekt, the Compose lint checks, tests,
-the coverage gates and `checkKotlinAbi` - plus `assemble`. One gate sits outside it: `buildSrc` is an
-included build the root-level tasks do not reach. So the full gate is two commands, and they are what
-to run locally before pushing:
+the coverage gates and `checkKotlinAbi` - plus `assemble`. Which of those a module carries depends on
+the convention plugins it applies: the vendored `swing-ui-animation` fork is exempt from ktlint,
+detekt and the lint checks. One gate sits outside `build`: `buildSrc` is an included build the
+root-level tasks do not reach. So the full gate is two commands, and they are what to run locally
+before pushing:
 
 ```bash
 ./gradlew :buildSrc:ktlintCheck :buildSrc:detekt
@@ -89,8 +94,9 @@ Piece by piece:
   ```bash
   ./gradlew updateKotlinAbi
   ```
-  Commit the updated `swing-ui/api/swing-ui.api` (and `swing-ui-test/api/swing-ui-test.api` if the
-  test module's surface changed). A public-API change should be intentional and reviewed.
+  Commit whichever of `swing-ui/api/swing-ui.api`, `swing-ui-test/api/swing-ui-test.api` and
+  `swing-ui-animation/api/swing-ui-animation.api` the change moved. A public-API change should be
+  intentional and reviewed.
 - **`:buildSrc:ktlintCheck` / `:buildSrc:detekt`** - formatting, lint and static analysis for the
   convention plugins. Run them whenever you touch anything under `buildSrc/`.
 - **`jacocoTestCoverageVerification`** - `swing-ui`, `swing-ui-test` and `swing-ui-animation` each

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Version](https://img.shields.io/github/v/release/MatkovIvan/compose-swing-ui?sort=semver)](https://github.com/MatkovIvan/compose-swing-ui/releases/latest)
 [![Snapshot](https://github.com/MatkovIvan/compose-swing-ui/actions/workflows/snapshot.yml/badge.svg)](https://github.com/MatkovIvan/compose-swing-ui/actions/workflows/snapshot.yml)
+[![API reference](https://img.shields.io/badge/API-reference-blue)](https://matkovivan.github.io/compose-swing-ui/)
 
 A declarative, reactive way to build **Swing** UIs using Jetpack Compose's composition model -
 built on **Compose Runtime only**. No skiko, no Compose Multiplatform UI, no Skia renderer. Your
@@ -54,13 +55,16 @@ fun main() = application {
 }
 ```
 
+<!--- KNIT example-readme-01.kt -->
+
 A child of `BorderPanel` names its `BorderLayout` region on its own modifier: `north()`, `south()`,
 `center()`, and the rest of `BorderLayout`'s. A child that names no region occupies the center, so
 the panel's main content is written plainly.
 
 Every component family the library ships - text inputs, buttons, selection, layout containers,
 windows, dialogs and menus - is cataloged with the parameters that decide how it behaves in
-[`docs/COMPONENTS.md`](docs/COMPONENTS.md).
+[`docs/COMPONENTS.md`](docs/COMPONENTS.md). Every public declaration is documented in the
+[API reference](https://matkovivan.github.io/compose-swing-ui/), which tracks `master`.
 
 ## Mounting into existing Swing (`setContent`)
 
@@ -101,6 +105,8 @@ fun main() {
 }
 ```
 
+<!--- KNIT example-readme-02.kt -->
+
 `setContent` is called on the Event Dispatch Thread and returns a `DisposableHandle`; dispose it to
 tear the composition down. Nesting works: a `setContent` whose ancestor already hosts a composition
 joins that composition and shares its recomposition scope.
@@ -140,6 +146,8 @@ fun main() = application {
 }
 ```
 
+<!--- KNIT example-readme-03.kt -->
+
 The same tree fills a context menu through `SwingModifier.contextMenu { ... }` and a tray icon's menu
 through `Tray(menu = { ... })`. On a `JMenuBar` the application builds itself, `JMenuBar.setContent { ... }`
 takes it too.
@@ -177,6 +185,8 @@ fun SaveButton(onSave: () -> Unit) {
     )
 }
 ```
+
+<!--- KNIT example-readme-04.kt -->
 
 `lineBorder` and `emptyBorder` declare a border by its values and rebuild it only when they change.
 Hoist the other value objects a chain carries - a `Font` or an `Icon` - into `remember`.
@@ -235,6 +245,7 @@ Full quality-gate command (what CI runs):
   [`swing-ui-animation/README.md`](swing-ui-animation/README.md).
 - `swing-ui-test` - the test harness. See [`swing-ui-test/README.md`](swing-ui-test/README.md).
 - `samples/todo-app`, `samples/widgets-gallery` - runnable showcases.
+- `samples/docs` - the Kotlin snippets in this repository's Markdown, compiled by the build.
 
 ## Stability
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Compose Swing UI
 
+[![Version](https://img.shields.io/github/v/release/MatkovIvan/compose-swing-ui?sort=semver)](https://github.com/MatkovIvan/compose-swing-ui/releases/latest)
+[![Snapshot](https://github.com/MatkovIvan/compose-swing-ui/actions/workflows/snapshot.yml/badge.svg)](https://github.com/MatkovIvan/compose-swing-ui/actions/workflows/snapshot.yml)
+
 A declarative, reactive way to build **Swing** UIs using Jetpack Compose's composition model -
 built on **Compose Runtime only**. No skiko, no Compose Multiplatform UI, no Skia renderer. Your
 components are real `JButton`/`JLabel`/`JPanel` widgets, laid out by Swing's own `LayoutManager`s
@@ -11,7 +14,7 @@ Inspired by [Compose HTML](https://github.com/JetBrains/compose-multiplatform) (
 ## Quick start
 
 A minimal app using the `application` entry point, a `Window`, a couple of components, and
-`BorderPanel`'s region slots:
+`BorderPanel`'s regions:
 
 ```kotlin
 import androidx.compose.runtime.getValue
@@ -33,32 +36,27 @@ fun main() = application {
         var count by remember { mutableIntStateOf(0) }
 
         BorderPanel {
-            north {
-                Label(
-                    "Compose Swing UI",
-                    modifier = SwingModifier.horizontalAlignment(SwingConstants.CENTER),
-                )
+            Label(
+                "Compose Swing UI",
+                modifier = SwingModifier.north().horizontalAlignment(SwingConstants.CENTER),
+            )
+            FlowPanel {
+                Label("Count: $count")
+                Button("Increment", onClick = { count++ })
+                Button("Decrement", onClick = { count-- })
             }
-            center {
-                FlowPanel {
-                    Label("Count: $count")
-                    Button("Increment", onClick = { count++ })
-                    Button("Decrement", onClick = { count-- })
-                }
-            }
-            south {
-                Label(
-                    "Status: ready",
-                    modifier = SwingModifier.horizontalAlignment(SwingConstants.CENTER),
-                )
-            }
+            Label(
+                "Status: ready",
+                modifier = SwingModifier.south().horizontalAlignment(SwingConstants.CENTER),
+            )
         }
     }
 }
 ```
 
-`BorderPanel` exposes each `BorderLayout` region as a declarative slot in a receiver DSL; declare only
-the regions you need.
+A child of `BorderPanel` names its `BorderLayout` region on its own modifier: `north()`, `south()`,
+`center()`, and the rest of `BorderLayout`'s. A child that names no region occupies the center, so
+the panel's main content is written plainly.
 
 Every component family the library ships - text inputs, buttons, selection, layout containers,
 windows, dialogs and menus - is cataloged with the parameters that decide how it behaves in
@@ -184,11 +182,10 @@ fun SaveButton(onSave: () -> Unit) {
 Hoist the other value objects a chain carries - a `Font` or an `Icon` - into `remember`.
 
 Domain callbacks like `onClick` and `onValueChange` stay ordinary parameters; only cross-cutting
-styling and interaction flow through `modifier`. Builders are grouped by concern: appearance, content
-placement, button painting, text colors, layout, metadata, interaction (which carries the typed
-listener builders), keyboard, data transfer, and accessibility. See
-[`docs/CUSTOM-COMPONENTS.md`](docs/CUSTOM-COMPONENTS.md) for what an unhoisted instance costs, and for
-writing your own modifier elements and listeners.
+styling and interaction flow through `modifier`. Builders are grouped by concern, one package each:
+appearance, layout, interaction, listener, keyboard, data transfer, and accessibility. See
+[`docs/CUSTOM-COMPONENTS.md`](docs/CUSTOM-COMPONENTS.md) for what an unhoisted instance costs, and
+for writing your own modifier elements and listeners.
 
 ## Bring your own Swing component
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("buildsrc.convention.central-publishing")
+    id("buildsrc.convention.api-reference")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     implementation(libs.androidLint.gradle.plugin)
     // Contributes each publishing module's publications to the root project's Central Portal aggregation.
     implementation(libs.nmcp.gradle.plugin)
+    // Applied by the publishing convention, and aggregated by the api-reference convention.
+    implementation(libs.dokka.gradle.plugin)
 }
 
 // buildSrc is an included build and cannot apply its own precompiled `kotlin-quality` convention

--- a/buildSrc/src/main/kotlin/buildsrc/convention/PublishingVersion.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/PublishingVersion.kt
@@ -1,0 +1,19 @@
+// Version derivation shared by the module publications and the API reference, so the version the
+// documentation carries and the version the artifacts carry come from one rule.
+package buildsrc.convention
+
+import org.gradle.api.Project
+
+private const val DEFAULT_VERSION: String = "0.1.0-SNAPSHOT"
+
+/**
+ * The version published artifacts and the API reference carry.
+ *
+ * Defaults to `0.1.0-SNAPSHOT`. `-Pversion=X.Y.Z` overrides it, and `-PversionSuffix=alpha.1`
+ * appends a pre-release suffix.
+ */
+public fun Project.resolvePublishVersion(): String {
+    val base = providers.gradleProperty("version").orNull?.takeIf { it.isNotBlank() } ?: DEFAULT_VERSION
+    val suffix = providers.gradleProperty("versionSuffix").orNull?.takeIf { it.isNotBlank() }
+    return if (suffix == null) base else "$base-$suffix"
+}

--- a/buildSrc/src/main/kotlin/buildsrc/convention/WindowSystemLock.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/WindowSystemLock.kt
@@ -1,0 +1,20 @@
+// Service type for the `buildsrc.convention.window-system-lock` precompiled plugin.
+// Kept as a plain Kotlin file (not inside the .gradle.kts script), matching the project's convention
+// of extracting non-DSL declarations so the script stays readable.
+package buildsrc.convention
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+/**
+ * Held by every test task that shows real windows, and granted to one of them at a time.
+ *
+ * Which of this process's windows the window system is attending to - which one is focused, which has
+ * been minimized - is a single state for the whole machine, and a test that asserts on it loses the
+ * assertion the moment another test opens a window of its own. Losing it reports a withheld capability
+ * and skips, so the damage is silent: coverage that stops running while the build stays green.
+ *
+ * Gradle runs tasks of different projects concurrently, which is what puts two such tasks on the machine
+ * at once. Tasks within one project are already serialized, so this constrains only across projects.
+ */
+public abstract class WindowSystemLock : BuildService<BuildServiceParameters.None>

--- a/buildSrc/src/main/kotlin/buildsrc/convention/api-reference.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/api-reference.gradle.kts
@@ -1,0 +1,38 @@
+// Renders the API reference of every published module as one HTML site. Applied to the root project,
+// which owns the aggregation the site is built from.
+package buildsrc.convention
+
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+plugins {
+    id("org.jetbrains.dokka")
+}
+
+// Precompiled script plugins do not get generated `libs` accessors, so resolve the catalog directly.
+private val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+private fun requiredLibrary(alias: String) =
+    libs
+        .findLibrary(alias)
+        .orElseThrow { IllegalStateException("Missing library '$alias' in gradle/libs.versions.toml") }
+
+dokka {
+    moduleName.set(rootProject.name)
+    // The versioning plugin stamps the version this site documents into its header, and switches
+    // between it and the generated documentation of earlier versions placed in `olderVersionsDir`.
+    pluginsConfiguration.versioning {
+        version.set(resolvePublishVersion())
+    }
+}
+
+dependencies {
+    dokkaPlugin(requiredLibrary("dokka-versioning-plugin"))
+
+    // Applying the publishing convention is what enrols a module: it brings the Dokka plugin that
+    // exposes the module's documentation to the aggregation. Modules without it, the samples among
+    // them, expose nothing and stay out of the site.
+    subprojects.forEach { module ->
+        module.plugins.withId("buildsrc.convention.publishing") { dokka(module) }
+    }
+}

--- a/buildSrc/src/main/kotlin/buildsrc/convention/jacoco-coverage.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/jacoco-coverage.gradle.kts
@@ -1,6 +1,7 @@
 package buildsrc.convention
 
 import org.gradle.kotlin.dsl.create
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
@@ -10,8 +11,20 @@ plugins {
 
 private val coverage = extensions.create<JacocoCoverageExtension>("jacocoCoverage")
 
+// A module may run its tests across more than one task. The report has to take in every one of them, or
+// the floors below are measured against a fraction of the suite and pass or fail on the split rather
+// than on the coverage. Each task contributes its own file as it is configured, which keeps the report
+// off the task container: asking it for every test task while it is being iterated is what a plain
+// `executionData(tasks.withType<Test>())` does, and that is refused.
+private val testExecutionData = objects.fileCollection()
+
+tasks.withType<Test>().configureEach {
+    testExecutionData.from(extensions.getByType<JacocoTaskExtension>().destinationFile)
+}
+
 tasks.named<JacocoReport>("jacocoTestReport") {
-    dependsOn(tasks.named("test"))
+    dependsOn(tasks.withType<Test>())
+    executionData.setFrom(testExecutionData)
     reports {
         xml.required.set(true)
         html.required.set(true)

--- a/buildSrc/src/main/kotlin/buildsrc/convention/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/publishing.gradle.kts
@@ -7,19 +7,13 @@ plugins {
     `maven-publish`
     signing
     id("com.gradleup.nmcp")
+    id("org.jetbrains.dokka")
 }
 
 private val publishGroup: String =
     providers.gradleProperty("group").orNull?.takeIf { it.isNotBlank() }
         ?: "dev.matkov.compose.swing"
-// Defaults to 0.1.0-SNAPSHOT, overridable with -Pversion=X.Y.Z; -PversionSuffix=... (for example
-// alpha.1, rc.1) appends a pre-release suffix.
-private val publishVersion: String =
-    run {
-        val base = providers.gradleProperty("version").orNull?.takeIf { it.isNotBlank() } ?: "0.1.0-SNAPSHOT"
-        val suffix = providers.gradleProperty("versionSuffix").orNull?.takeIf { it.isNotBlank() }
-        if (suffix == null) base else "$base-$suffix"
-    }
+private val publishVersion: String = resolvePublishVersion()
 
 group = publishGroup
 version = publishVersion
@@ -34,6 +28,10 @@ private val signingPassword: String = resolveSigningPassword()
 extensions.configure<JavaPluginExtension> {
     withSourcesJar()
     withJavadocJar()
+}
+
+dokka {
+    moduleName.set(project.name)
 }
 
 publishing {

--- a/buildSrc/src/main/kotlin/buildsrc/convention/window-system-lock.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/window-system-lock.gradle.kts
@@ -1,0 +1,13 @@
+package buildsrc.convention
+
+import org.gradle.api.provider.Provider
+
+// Applied by modules whose tests show real windows. See WindowSystemLock for what is being serialized.
+private val windowSystemLock: Provider<WindowSystemLock> =
+    gradle.sharedServices.registerIfAbsent("windowSystemLock", WindowSystemLock::class) {
+        maxParallelUsages.set(1)
+    }
+
+tasks.withType<Test>().configureEach {
+    usesService(windowSystemLock)
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -531,9 +531,9 @@ it prefers and leaves the rest to the arrangement. An explicit `maximumSize` cap
 `BoxPanel` is the direct `BoxLayout` wrapper, and a `ToolBar` lays its controls out the same way:
 each shares its leftover space out among the children that have room between the size they prefer and
 their maximum size, in proportion to that room. `Glue` is empty space with the most room of all, so it
-takes the largest share, and `Strut` and `RigidArea` are the fixed gaps between items. `FlowPanel`
-centers its children and gaps them by `5` pixels, and `GridPanel` starts as a single row that grows a
-column per child, with no gaps.
+takes the largest share, and `Strut`, `RigidArea` and `Spacer` (a `RigidArea` square) are the fixed
+gaps between items. `FlowPanel` centers its children and gaps them by `5` pixels, and `GridPanel`
+starts as a single row that grows a column per child, with no gaps.
 
 `GridBagPanel`'s `item` takes one parameter per `GridBagConstraints` field, under the field's own
 name and with its own default, so a grid-bag layout written against Swing carries over field for

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -6,6 +6,37 @@ per-parameter reference. The concepts behind the binding are in
 [`ARCHITECTURE.md`](ARCHITECTURE.md), and building a component of your own is
 [`CUSTOM-COMPONENTS.md`](CUSTOM-COMPONENTS.md).
 
+<!--- INCLUDE .*content.*
+import androidx.compose.runtime.*
+import org.jetbrains.compose.swing.components.*
+import org.jetbrains.compose.swing.components.button.*
+import org.jetbrains.compose.swing.components.layout.*
+import org.jetbrains.compose.swing.components.selection.*
+import org.jetbrains.compose.swing.components.text.*
+import org.jetbrains.compose.swing.modifier.*
+import org.jetbrains.compose.swing.modifier.interaction.*
+import org.jetbrains.compose.swing.modifier.layout.*
+import org.jetbrains.compose.swing.window.*
+import java.awt.Dimension
+import java.awt.GridBagConstraints
+import java.awt.Insets
+import javax.swing.*
+
+@Composable
+fun Example() {
+----- SUFFIX .*content.*
+}
+----- INCLUDE .*app.*
+import androidx.compose.runtime.*
+import org.jetbrains.compose.swing.components.*
+import org.jetbrains.compose.swing.components.button.*
+import org.jetbrains.compose.swing.components.layout.*
+import org.jetbrains.compose.swing.window.*
+import java.awt.Dimension
+
+fun main() =
+-->
+
 Two things hold for everything below.
 
 **Every parameter is reapplied on recomposition.** Pass state to a component and the widget follows
@@ -151,6 +182,8 @@ EditorPane(
 )
 ```
 
+<!--- CLEAR -->
+
 ---
 
 ## Buttons and choices
@@ -181,6 +214,8 @@ CheckBox("Word wrap", checked = wrap, onCheckedChange = { wrap = it })
 ToggleButton("Pin", selected = pinned, onSelectedChange = { pinned = it })
 ```
 
+<!--- CLEAR -->
+
 A `RadioGroup` owns the button group, so you declare the options and the selected index rather than
 wiring exclusivity yourself. The index is the composition's state on every pass, so a pick the caller
 does not adopt goes back to the declared option - including the option the group cleared without it
@@ -195,6 +230,8 @@ RadioGroup(selectedIndex = theme, onSelectionChange = { theme = it }) {
     option("Follow system")
 }
 ```
+
+<!--- KNIT example-components-content-01.kt -->
 
 An editable `ComboBox` has two outputs: `onSelectionChange` for a choice from the list, and
 `onValueCommit` for text typed into the editor. `itemContent` replaces the rendered cell with a
@@ -217,6 +254,8 @@ ComboBox(
     Label(if (isSelected) "> $item" else item)
 }
 ```
+
+<!--- KNIT example-components-content-02.kt -->
 
 `Slider` and `ProgressBar` both range over `0`..`100` by default and are horizontal, as is
 `Separator`. A slider's `labels` map declares the label table that `paintLabels` then paints; a
@@ -242,6 +281,8 @@ ProgressBar(value = zoom, min = 50, max = 200, stringPainted = true)
 Separator(orientation = SwingConstants.HORIZONTAL)
 ```
 
+<!--- KNIT example-components-content-03.kt -->
+
 `Slider` and `ProgressBar` also take a caller-owned `BoundedRangeModel` in place of `value`. The model
 owns the range; the library renders it and never writes to it, so mutating the model repaints the
 widgets without a recomposition. Handing the same instance to both is what lets a bar track a slider
@@ -253,6 +294,8 @@ val range = remember { DefaultBoundedRangeModel(30, 0, 0, 100) }
 Slider(model = range)
 ProgressBar(model = range)
 ```
+
+<!--- KNIT example-components-content-04.kt -->
 
 A `Spinner` shows its value through an editor, and two parameters decide which one. `format` is the
 pattern the spinner's own editor renders and parses with - a `DecimalFormat` pattern over a number
@@ -268,6 +311,8 @@ var hour by remember { mutableStateOf(9) }
 Spinner(hour, onValueChange = { hour = it.toInt() }, min = 0, max = 23, format = "00")
 Spinner(hour, onValueChange = { hour = it.toInt() }, min = 0, max = 23) { Label("$hour o'clock") }
 ```
+
+<!--- KNIT example-components-content-05.kt -->
 
 ---
 
@@ -303,6 +348,8 @@ ListBox(
 }
 ```
 
+<!--- KNIT example-components-content-06.kt -->
+
 A composable cell - a `ListBox` or `ComboBox` `itemContent`, a column's `cellContent`, a `Tree`'s
 `nodeContent` - composes **one** component, and that component is what the widget renders the row
 with: it is bounded at the row and laid out there. Compose several components into a panel and the row
@@ -319,6 +366,8 @@ ComboBox(items = languages, selectedItem = selected, onSelectionChange = { selec
     }
 }
 ```
+
+<!--- CLEAR -->
 
 A list measures each row by what its cell asks for. A tree does the same where its `rowHeight` is `0`,
 and otherwise gives every row the one height. A table never does: every one of its rows is the same
@@ -379,6 +428,8 @@ ScrollPane {
 }
 ```
 
+<!--- CLEAR -->
+
 A `Tree` is built from your own node type: a `root`, a `children` function, and a `label` for the
 text of a node. Selection and expansion are both a set of index paths - a `List<Int>` of child
 positions per node, walked from the root - so they mean the same thing across two compositions of the
@@ -420,6 +471,8 @@ Tree(
 }
 ```
 
+<!--- CLEAR -->
+
 A `ListState` holds what one `ListBox` has selected, and a `TreeState` what one `Tree` has selected and
 open. Each also carries the gesture that brings one row into view when the application decides to - a
 row just added, a search hit, a node a load has just filled in. Hoist one with `rememberListState()`
@@ -445,6 +498,8 @@ ScrollPane {
     ListBox(items = items, state = state, modifier = SwingModifier.viewport())
 }
 ```
+
+<!--- CLEAR -->
 
 To reveal a region of a scroll pane's content rather than a row of a widget, use
 [`ScrollState.revealRect`](#scrollstate).
@@ -501,6 +556,8 @@ BorderPanel {
 }
 ```
 
+<!--- CLEAR -->
+
 `Row` and `Column` are the two single-axis stacks you reach for most. Along its axis, a child keeps
 the size it prefers, and the space the container has left over is placed by an `Arrangement`
 (`Top`, `Bottom`, `Start`, `End`, `Center`, `SpaceBetween`, `SpaceAround`, `SpaceEvenly`,
@@ -523,6 +580,8 @@ Column(verticalArrangement = Arrangement.spacedBy(8), horizontalAlignment = Alig
     Label("Status", modifier = SwingModifier.align(Alignment.CenterHorizontally))
 }
 ```
+
+<!--- CLEAR -->
 
 A weighted child takes its share of what is left after every child that claims none has taken the
 size it prefers, in proportion to the weights; `weight(w, fill = false)` lets it settle for the size
@@ -561,6 +620,8 @@ GridBagPanel {
 }
 ```
 
+<!--- KNIT example-components-content-07.kt -->
+
 A child that declares no `item` is laid out under `GridBagConstraints`' own defaults, which place it
 relative to the child before it.
 
@@ -578,6 +639,8 @@ CardPanel(selectedCard = step) {
 }
 Button("Next", onClick = { step = "payment" })
 ```
+
+<!--- CLEAR -->
 
 Every child of a `TabbedPane` is one tab's body and declares that tab with `tab(...)`, which carries the
 tab's title, icon, tooltip, enabled flag, mnemonic and colors, and can take over what the tab strip
@@ -609,6 +672,8 @@ TabbedPane(selectedIndex = tab, onSelectedIndexChange = { tab = it }) {
 }
 ```
 
+<!--- CLEAR -->
+
 A `SplitPane`'s `first` side is the left or the top depending on `orientation`, which defaults to
 `JSplitPane.HORIZONTAL_SPLIT`. `dividerLocation` is declared and `onDividerLocationChange` reports
 where the user dragged it; `resizeWeight` decides which side keeps extra space, and
@@ -631,6 +696,8 @@ SplitPane(
 }
 ```
 
+<!--- CLEAR -->
+
 A `ScrollPane` holds nothing but its regions, so every child declares one: `viewport()`, `rowHeader()`,
 `columnHeader()` or `corner(...)`. `viewport()` also carries how far the pane scrolls per arrow button
 and per page, and whether the content is laid out at the viewport's own width or height - each `null`
@@ -648,6 +715,8 @@ ScrollPane(horizontalScrollbar = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER) {
 }
 ```
 
+<!--- CLEAR -->
+
 A `ToolBar` is horizontal and floatable by default. `floating` declares whether the bar stands in a
 window of its own, and `onFloatingChange` reports where the user dragged it - or hands back the docked
 state a bar that cannot float settles for.
@@ -661,6 +730,8 @@ ToolBar(floatable = false, rollover = true) {
 }
 ```
 
+<!--- CLEAR -->
+
 A `LayeredPane` stacks children on integer depths - higher layers paint above lower ones, and within
 one layer the children stack in the order the composition declares them, the first of them on top. A
 child that declares no layer stands on `JLayeredPane.DEFAULT_LAYER`. It lays nothing out, so each
@@ -672,6 +743,8 @@ LayeredPane {
     Label("Floating", modifier = SwingModifier.layer(JLayeredPane.PALETTE_LAYER).bounds(16, 16, 120, 24))
 }
 ```
+
+<!--- CLEAR -->
 
 A `DesktopPane` hosts internal frames. Each frame declares a title, its window controls, and either
 plain `bounds` - where it starts, and wherever the user then leaves it - or an
@@ -706,6 +779,8 @@ DesktopPane {
     }
 }
 ```
+
+<!--- CLEAR -->
 
 To place children under a layout manager of your own, `layoutConstraint` is the builder a container you
 write yourself names its own placements over - see
@@ -754,6 +829,8 @@ Window(onCloseRequest = ::exitApplication) {
 }
 ```
 
+<!--- CLEAR -->
+
 A window exists while it is composed: opening one is composing it, closing it is not composing it,
 and `onCloseRequest` is where you flip the state that decides. `title` starts empty, `resizable` is
 `true`, `alwaysOnTop` is `false`, `undecorated` is `false`, and a dialog's `modality` is
@@ -775,6 +852,8 @@ application {
 }
 ```
 
+<!--- KNIT example-components-app-01.kt -->
+
 ```kotlin
 var asking by remember { mutableStateOf(false) }
 
@@ -793,6 +872,8 @@ if (asking) {
     }
 }
 ```
+
+<!--- KNIT example-components-content-08.kt -->
 
 To mount a composition into a Swing window or container you already own, use `setContent` - see
 [`ARCHITECTURE.md`](ARCHITECTURE.md#mounting-a-composition).
@@ -843,6 +924,8 @@ Row {
 }
 ```
 
+<!--- KNIT example-components-content-09.kt -->
+
 ---
 
 ## Menus
@@ -891,6 +974,8 @@ bar.setContent {
 frame.jMenuBar = bar
 ```
 
+<!--- CLEAR -->
+
 There is no command type, so one command reached from two surfaces - a menu item and a toolbar button
 that go gray together - is a shared value and a shared modifier. Both surfaces read the one state and
 apply the one chain, so enabling and disabling them is a single state write.
@@ -916,6 +1001,8 @@ Window(onCloseRequest = ::exitApplication) {
 }
 ```
 
+<!--- CLEAR -->
+
 ---
 
 ## Drawing
@@ -933,6 +1020,8 @@ Column {
     Slider(value = radius, onValueChange = { radius = it }, min = 4, max = 80)
 }
 ```
+
+<!--- KNIT example-components-content-10.kt -->
 
 ---
 
@@ -954,6 +1043,8 @@ application {
     }
 }
 ```
+
+<!--- CLEAR -->
 
 ---
 
@@ -997,6 +1088,8 @@ val report = rememberDocumentState("<h1>Report</h1><p>Q3 was <b>strong</b>.</p>"
 EditorPane(state = report, editable = false)
 ```
 
+<!--- KNIT example-components-content-11.kt -->
+
 ```kotlin
 val note = rememberDocumentState("Dear ")
 
@@ -1015,6 +1108,8 @@ Column {
     Button("Undo", modifier = SwingModifier.enabled(note.canUndo), onClick = note::undo)
 }
 ```
+
+<!--- KNIT example-components-content-12.kt -->
 
 ### `FormattedValueState`
 

--- a/docs/CUSTOM-COMPONENTS.md
+++ b/docs/CUSTOM-COMPONENTS.md
@@ -4,6 +4,11 @@ Compose Swing UI ships wrappers for the common widgets (`Button`, `TextField`, `
 real applications host many bespoke Swing components. Wrapping your own component uses the same
 public `SwingNode` API every built-in wrapper is built on. This guide shows how.
 
+<!--- INCLUDE .*modifier.*
+import org.jetbrains.compose.swing.modifier.SwingModifier
+import javax.swing.JComponent
+-->
+
 ## The mental model
 
 A composable component is a function that wraps a single Swing `Component`. You describe the
@@ -19,6 +24,8 @@ public fun MyWidget(/* state + callbacks */) {
     )
 }
 ```
+
+<!--- CLEAR -->
 
 - `factory` runs **once**, when the node enters the composition. Build (and do one-time
   configuration of) your Swing component here. Whatever it reads from the composable body, it reads
@@ -103,6 +110,8 @@ public inline fun <reified T : Component> SwingNode(
 )
 ```
 
+<!--- CLEAR -->
+
 The container overload additionally hosts composable `content` as children - use it when your
 component is a `java.awt.Container` (e.g. a custom `JPanel`) that should contain further
 composables:
@@ -119,6 +128,8 @@ public inline fun <reified T : Component> SwingNode(
     crossinline content: @Composable @SwingComposable () -> Unit,
 )
 ```
+
+<!--- CLEAR -->
 
 `childPlacement` says how the component holds the children `content` emits. The default,
 `ChildPlacement.Indexed`, adds them to the container by index and lets its layout manager place them.
@@ -175,6 +186,8 @@ public fun Banner(
 }
 ```
 
+<!--- CLEAR -->
+
 Two rules the framework holds you to. The uninstall action must remove the child **by identity** - the
 positions of a host's children shift as siblings come and go, so an index captured at install time can
 name another child by the time uninstall runs. And a component that declares your region while sitting
@@ -215,6 +228,8 @@ and lifecycle-safe listeners you apply a `SwingModifier` chain.
 set(value) { /* this: T */ this.someProperty = it }
 ```
 
+<!--- CLEAR -->
+
 `set` records `value` and runs the block (with the component as `this` and `value` as `it`) on the
 first composition, then again **only when `value` changes** between recompositions. This is the
 idiomatic way to push one piece of state onto one Swing property. Call `set` once per property you
@@ -241,6 +256,8 @@ SwingNode(
     },
 )
 ```
+
+<!--- CLEAR -->
 
 `update` behaves like `set` but skips the first composition, so use it - and only it - for a value the
 `factory` passed to the constructor. `set` would write that value a second time on the composition
@@ -331,6 +348,8 @@ fun MyCheckBox(
 }
 ```
 
+<!--- KNIT example-custom-01.kt -->
+
 ### The component is fully controlled
 
 Once a property is bound this way, the component is **fully controlled**: a change the caller does not
@@ -374,6 +393,8 @@ set(dividerLocation) { location ->
     }
 }
 ```
+
+<!--- CLEAR -->
 
 The `applied` here is the same `AppliedValue` its listener calls `observed` on - `write` is what lets the
 two share one mirror without fighting the user the way re-asserting the declaration on every pass would.
@@ -475,6 +496,8 @@ fun rememberRangeState(
     return remember { RangeState(model) }
 }
 ```
+
+<!--- KNIT example-custom-02.kt -->
 
 ### What the widget settles on is what the holder reports
 
@@ -578,6 +601,8 @@ public fun MyWidget(
     )
 }
 ```
+
+<!--- CLEAR -->
 
 The parameter and that call are not a courtesy to callers who want a border. Where a child sits in its
 parent - a `BorderLayout` region, a `GridBagConstraints`, a cell in a manager of your own - is declared
@@ -737,6 +762,8 @@ public fun SwingModifier.toolTip(text: String?): SwingModifier =
     then(ToolTipElement(text))
 ```
 
+<!--- KNIT example-custom-modifier-01.kt -->
+
 The built-in `toolTip` builder is the same property shape; the code above is the public `NodeElement`/`Node`
 path you write for a property the library does not ship.
 
@@ -759,6 +786,8 @@ listeners the host app attached are untouched.
 val onMove = remember { object : MouseAdapter() { override fun mouseMoved(e: MouseEvent) { /* ... */ } } }
 SwingModifier.name("canvas").mouseMotionListener(onMove)
 ```
+
+<!--- CLEAR -->
 
 The builders, by listener type: `mouseListener`, `mouseMotionListener`, `mouseWheelListener`,
 `keyListener`, `focusListener`, `componentListener`, `hierarchyListener`, `containerListener`
@@ -806,6 +835,8 @@ SwingModifier.listener<MyType, SomeListener>(
     detach = { component, l -> component.removeSomeListener(l) },
 )
 ```
+
+<!--- CLEAR -->
 
 `listener<T, L>` is reified on the target component type `T`, so `attach`/`detach` receive the
 component already typed, and a node whose component is not a `T` is rejected at apply with a clear
@@ -903,6 +934,8 @@ fun MySpinner(
 private val JSpinner.numberModel: SpinnerNumberModel get() = model as SpinnerNumberModel
 ```
 
+<!--- KNIT example-custom-03.kt -->
+
 The `if (this.value != it)` guard in the `value` setter prevents a feedback loop where applying the
 incoming state would itself fire the change listener.
 
@@ -937,6 +970,8 @@ fun TitledGroup(
     )
 }
 ```
+
+<!--- KNIT example-custom-04.kt -->
 
 A container takes a `modifier` and applies it for the same reason a leaf does, and for one more: a
 container is itself a child of whatever holds it, so the group above is placed in a `BorderPanel`

--- a/docs/CUSTOM-COMPONENTS.md
+++ b/docs/CUSTOM-COMPONENTS.md
@@ -1052,9 +1052,9 @@ follows all three:
   runs: a replacement need not wait for the child it replaces to go, and only what remains at the end is
   what the composition declares. A container reaching its children through regions leaves that to the
   framework, which holds a `ChildPlacement.Slots` host to one child per region once the pass settles, as
-  `SplitPane` does for its two sides; one placing them under constraints runs its own check from a
-  `SideEffect`, which the runtime invokes after this composition's changes have reached the components,
-  as `CardPanel` does over the cards its deck holds. Either way the set a check runs against is what the
+  `SplitPane` does for its two sides; one placing them under constraints runs its own check on the
+  event-dispatch turn after the change pass, once a parked node's deactivation has run too, as
+  `CardPanel` does over the cards its deck holds. Either way the set a check runs against is what the
   container actually holds - its own children, its layout's own records - rather than a list a block
   gathered.
 

--- a/docs/TESTING-COMPONENTS.md
+++ b/docs/TESTING-COMPONENTS.md
@@ -110,7 +110,8 @@ onNodeWithTag("name-field").performTextInput("Ada")
 
 ## Asserting state
 
-Assertions are available on a `SwingNodeInteraction`; each returns the interaction so they chain:
+Assertions are available on a `SwingNodeInteraction`; each returns the interaction so they chain,
+except `assertDoesNotExist()`, which ends the chain:
 
 - `assertExists()` / `assertDoesNotExist()`
 - `assertIsDisplayed()` — assert the layout gave the component real bounds.

--- a/docs/TESTING-COMPONENTS.md
+++ b/docs/TESTING-COMPONENTS.md
@@ -5,6 +5,23 @@ components — and the top-level windows the composition realizes — assert the
 interactions through them. This guide shows how to write behavioral tests — tests that exercise
 state → recomposition → visible change through the public API.
 
+<!--- INCLUDE .*fragment.*
+import androidx.compose.runtime.*
+import org.jetbrains.compose.swing.test.*
+import org.jetbrains.compose.swing.test.interaction.*
+import javax.swing.*
+
+fun example() = runComposeSwingTest {
+----- SUFFIX .*fragment.*
+}
+----- INCLUDE .*case.*
+import androidx.compose.runtime.*
+import org.jetbrains.compose.swing.components.*
+import org.jetbrains.compose.swing.components.button.*
+import org.jetbrains.compose.swing.test.*
+import kotlin.test.*
+-->
+
 ## Setup
 
 Add the harness to the dependencies of the module under test:
@@ -15,6 +32,8 @@ dependencies {
     testImplementation(project(":swing-ui-test"))
 }
 ```
+
+<!--- CLEAR -->
 
 Then write a plain `@Test` method whose body is a `runComposeSwingTest { … }` block. Inside the block you
 call `setContent { … }` to mount your composable, and the harness, finders, assertions, and actions
@@ -40,6 +59,8 @@ class CounterTest {
     }
 }
 ```
+
+<!--- KNIT example-testing-01.kt -->
 
 `setContent` waits for the composition to settle before returning, so by the next line the tree
 reflects the initial state. After an action that writes Compose state, the harness settles again
@@ -72,6 +93,8 @@ onAllNodesWithTag("item").onLast().assertTextEquals("newest")
 onAllNodesOfType<JCheckBox>().assertAll(SwingMatcher.isEnabled())
 ```
 
+<!--- KNIT example-testing-fragment-01.kt -->
+
 ### Structure
 
 Where a component sits in the tree is expressed by matchers — `hasParent`, `hasAnyChild`,
@@ -82,6 +105,8 @@ scoped to a subtree by describing it rather than by holding a component:
 onAllNodesOfType<JLabel>().filter(SwingMatcher.hasAnyAncestor(SwingMatcher.hasTestTag("editor")))
 ```
 
+<!--- KNIT example-testing-fragment-02.kt -->
+
 From an interaction you can also step to the nodes around it with `onParent()`, `onChild()`,
 `onChildren()`, `onChildAt(index)`, `onSibling()`, `onSiblings()`, `onAncestors()` and
 `onDescendants()`. A step is as lazy as the query it extends, and `onAncestors()` stops at the root
@@ -91,6 +116,8 @@ the query searches:
 onNodeWithTag("editor").onDescendants().filter(SwingMatcher.isOfType<JLabel>()).assertCountEquals(2)
 onNodeWithText("Save").onParent().assert(SwingMatcher.isEnabled())
 ```
+
+<!--- KNIT example-testing-fragment-03.kt -->
 
 ### Test tags
 
@@ -104,9 +131,13 @@ import org.jetbrains.compose.swing.modifier.appearance.testTag
 TextField(value = name, onValueChange = { name = it }, modifier = SwingModifier.testTag("name-field"))
 ```
 
+<!--- CLEAR -->
+
 ```kotlin
 onNodeWithTag("name-field").performTextInput("Ada")
 ```
+
+<!--- KNIT example-testing-fragment-04.kt -->
 
 ## Asserting state
 
@@ -134,12 +165,16 @@ onNodeWithTag("submit")
     .assertTextEquals("Submit")
 ```
 
+<!--- KNIT example-testing-fragment-05.kt -->
+
 A check that is not one of the named assertions is still asserted through the node: `assert(matcher)`
 takes any `SwingMatcher`, so the failure message keeps the finder's context:
 
 ```kotlin
 onNodeOfType<JCheckBox>().assert(SwingMatcher.isSelected())
 ```
+
+<!--- KNIT example-testing-fragment-06.kt -->
 
 `fetch<T>()` hands back the live component itself. Its purpose is the comparison only the component
 can answer: that the widget settled on the value the composition declared, or that the same instance
@@ -151,6 +186,8 @@ import javax.swing.JList
 val list = onNodeOfType<JList<*>>().fetch<JList<*>>()
 assertEquals(2, list.selectedIndex, "the declared selection is the one the widget holds")
 ```
+
+<!--- CLEAR -->
 
 Prefer an assertion or a matcher wherever one covers the property, and reach for `fetch<T>()` where
 the Swing side of the contract is itself the subject.
@@ -170,6 +207,8 @@ val items = (0 until fileMenu.itemCount).map { fileMenu.getItem(it)?.text }
 assertEquals(listOf("New", null, "Open"), items)
 ```
 
+<!--- CLEAR -->
+
 Only the menu's own level is read this way: a submenu appears as its own item, named by its `text`,
 and what it drops down is read the same way, off the `JMenu` that item is.
 
@@ -188,6 +227,8 @@ onNodeWithTag("amount").performTextReplacement("42")
 onNodeWithText("Save").performClick()
 ```
 
+<!--- KNIT example-testing-fragment-07.kt -->
+
 ### Tabs
 
 A tabbed pane's strip is drawn by the look and feel rather than built from child components, so there
@@ -199,6 +240,8 @@ position to click; the action says so rather than landing on nothing.
 ```kotlin
 onNodeOfType<JTabbedPane>().performTabClick(2)
 ```
+
+<!--- KNIT example-testing-fragment-08.kt -->
 
 ### Focus
 
@@ -218,6 +261,8 @@ component the test did not expect is a different case — a real failure, assert
 onNodeWithTag("amount").performFocusLost()
 onNodeWithTag("amount").assertTextEquals("42.00")
 ```
+
+<!--- KNIT example-testing-fragment-09.kt -->
 
 ## Callback failures
 
@@ -247,6 +292,8 @@ fun aThrowingCallbackIsContainedAndReported() = runComposeSwingTest {
     assertEquals("boom", failures.single().message)
 }
 ```
+
+<!--- KNIT example-testing-case-01.kt -->
 
 ## Testing windows and dialogs
 
@@ -285,6 +332,8 @@ fun settingsWindowShowsItsContent() = runComposeSwingTest {
     window.onNodeWithText("Apply").assertIsEnabled()
 }
 ```
+
+<!--- KNIT example-testing-case-02.kt -->
 
 A dialog show is applied on its own event-dispatch turn; the idle gate drains it, so after a state
 change plus `awaitIdle()` the realized dialog already reflects the declared visibility.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ coroutines = "1.9.0"
 androidxCollection = "1.5.0"
 androidxAnnotation = "1.8.1"
 androidxLifecycle = "2.9.4"
+androidxNavigation3 = "1.1.0"
 jetbrainsAnnotations = "23.0.0"
 detekt = "2.0.0-alpha.5"
 ktlint = "1.8.0"
@@ -20,6 +21,7 @@ composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "c
 androidxCollection = { module = "androidx.collection:collection", version.ref = "androidxCollection" }
 androidxAnnotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 androidxLifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidxNavigation3Runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidxNavigation3" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinxCoroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
 jetbrainsAnnotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,38 +1,43 @@
 [versions]
-kotlin = "2.3.20"
-compose = "1.10.0"
-coroutines = "1.9.0"
-androidxCollection = "1.5.0"
+androidLint = "9.2.1"
 androidxAnnotation = "1.8.1"
+androidxCollection = "1.5.0"
 androidxLifecycle = "2.9.4"
 androidxNavigation3 = "1.1.0"
-jetbrainsAnnotations = "23.0.0"
+compose = "1.10.0"
+composeLintChecks = "1.5.2"
+coroutines = "1.9.0"
 detekt = "2.0.0-alpha.5"
+dokka = "2.2.0"
+jetbrainsAnnotations = "23.0.0"
+knit = "0.5.1"
+kotlin = "2.3.20"
 ktlint = "1.8.0"
 ktlint-gradle = "14.0.1"
-androidLint = "9.2.1"
-composeLintChecks = "1.5.2"
 nmcp = "1.6.1"
 
 [libraries]
-kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlinComposePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
-composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
-androidxCollection = { module = "androidx.collection:collection", version.ref = "androidxCollection" }
+androidLint-gradle-plugin = { module = "com.android.lint:com.android.lint.gradle.plugin", version.ref = "androidLint" }
 androidxAnnotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
+androidxCollection = { module = "androidx.collection:collection", version.ref = "androidxCollection" }
 androidxLifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidxNavigation3Runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidxNavigation3" }
+composeLintChecks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
+composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+dokka-versioning-plugin = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
+jetbrainsAnnotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
+kotlinComposeCompilerPluginEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable", version.ref = "kotlin" }
+kotlinComposePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinxCoroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
-jetbrainsAnnotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
 kotlinxCoroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 ktlint-gradle-plugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint-gradle" }
-androidLint-gradle-plugin = { module = "com.android.lint:com.android.lint.gradle.plugin", version.ref = "androidLint" }
-composeLintChecks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
-kotlinComposeCompilerPluginEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable", version.ref = "kotlin" }
 nmcp-gradle-plugin = { module = "com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin", version.ref = "nmcp" }
 
 [plugins]
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+knit = { id = "org.jetbrains.kotlinx.knit", version.ref = "knit" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }

--- a/knit.properties
+++ b/knit.properties
@@ -1,0 +1,3 @@
+# Both paths are relative to this file.
+knit.dir=samples/docs/build/generated/knit/example/
+knit.package=example

--- a/samples/docs/build.gradle.kts
+++ b/samples/docs/build.gradle.kts
@@ -1,0 +1,58 @@
+plugins {
+    id("buildsrc.convention.kotlin-jvm")
+    alias(libs.plugins.knit)
+}
+
+// Compiles the Kotlin example files Knit generates from the fenced snippets in the repository's
+// Markdown, so the build checks what the documentation shows. The module has no sources of its own:
+// everything it compiles is generated into its build directory. Generated code is not hand-written
+// code, so the shared ktlint/detekt/lint, publishing, coverage and ABI gates stay off this module.
+
+knit {
+    // Only the documents that carry Knit directives. The default file set walks the whole checkout,
+    // generated sources under build directories included.
+    files =
+        fileTree(project.rootDir) {
+            include("README.md")
+            include("docs/*.md")
+        }
+}
+
+// Knit's output directory, named by `knit.dir` in the repository's knit.properties. The Knit task
+// itself declares no outputs, and files a task writes without declaring them stay stale in Gradle's
+// view of the file system - a following compile would keep reporting itself up to date over sources
+// Knit has just rewritten. Naming the directory here is what makes an edited snippet reach the
+// compiler.
+val knitOutputDir = layout.buildDirectory.dir("generated/knit")
+
+val knitTask =
+    tasks.named("knit") {
+        outputs.dir(knitOutputDir)
+    }
+
+kotlin.sourceSets.main {
+    kotlin.srcDir(knitOutputDir)
+}
+
+tasks.compileKotlin {
+    dependsOn(knitTask)
+}
+
+// `knitCheck` compares the generated files against what the Markdown would produce now. That can only
+// differ when the files are kept in the repository; here they are produced from the Markdown on every
+// run, so the comparison has nothing left to catch - and `check` orders it against no other task, so
+// on a clean build directory it can just as well run before the files exist and fail. Compiling the
+// generated sources is the gate that replaces it.
+tasks.named("check") {
+    setDependsOn(dependsOn.filterNot { (it as? TaskProvider<*>)?.name == "knitCheck" })
+}
+
+dependencies {
+    implementation(project(":swing-ui"))
+    implementation(project(":swing-ui-animation"))
+    implementation(project(":swing-ui-test"))
+    // The generated examples live in the main source set, where nothing runs them; the harness snippets
+    // still name `kotlin.test.Test` and JUnit's assumptions, so the framework binding has to be explicit
+    // here rather than inherited from a test task.
+    implementation(kotlin("test-junit5"))
+}

--- a/samples/todo-app/README.md
+++ b/samples/todo-app/README.md
@@ -1,8 +1,8 @@
 # todo-app sample
 
 A small to-do application built with Compose Swing UI. It shows the Compose-over-Swing shape: a thin
-Swing `main` that hands a `JFrame` to `setContent`, and a reactive composable tree that knows nothing
-about frames or look-and-feels.
+`main` - `application { Window(...) }` - and a reactive composable tree that knows nothing about
+frames or look-and-feels.
 
 ## Run
 

--- a/samples/widgets-gallery/build.gradle.kts
+++ b/samples/widgets-gallery/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     implementation(project(":swing-ui"))
     implementation(project(":swing-ui-animation"))
+    implementation(libs.androidxNavigation3Runtime)
 
     testImplementation(kotlin("test"))
     testImplementation(project(":swing-ui-test"))

--- a/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/WidgetsGalleryApp.kt
+++ b/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/WidgetsGalleryApp.kt
@@ -3,17 +3,23 @@ package org.jetbrains.compose.swing.samples.widgets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import org.jetbrains.compose.swing.components.CheckBoxMenuItem
 import org.jetbrains.compose.swing.components.Label
 import org.jetbrains.compose.swing.components.Menu
 import org.jetbrains.compose.swing.components.MenuItem
 import org.jetbrains.compose.swing.components.MenuSeparator
 import org.jetbrains.compose.swing.components.RadioButtonMenuGroup
+import org.jetbrains.compose.swing.components.button.Button
 import org.jetbrains.compose.swing.components.layout.BorderPanel
+import org.jetbrains.compose.swing.components.layout.FlowPanel
 import org.jetbrains.compose.swing.components.layout.ScrollPane
 import org.jetbrains.compose.swing.components.selection.ListBox
 import org.jetbrains.compose.swing.modifier.SwingModifier
@@ -21,12 +27,14 @@ import org.jetbrains.compose.swing.modifier.accessibility.accessibleName
 import org.jetbrains.compose.swing.modifier.appearance.emptyBorder
 import org.jetbrains.compose.swing.modifier.appearance.horizontalAlignment
 import org.jetbrains.compose.swing.modifier.applyModifier
+import org.jetbrains.compose.swing.modifier.interaction.enabled
 import org.jetbrains.compose.swing.modifier.layout.preferredSize
 import org.jetbrains.compose.swing.modifier.listener.actionListener
 import org.jetbrains.compose.swing.node.MenuNode
 import org.jetbrains.compose.swing.samples.widgets.text.setEditorText
 import org.jetbrains.compose.swing.window.LocalWindow
 import java.awt.Dimension
+import java.awt.FlowLayout
 import java.awt.Toolkit
 import java.awt.event.ActionListener
 import java.awt.event.KeyEvent
@@ -92,31 +100,60 @@ internal fun ShowcaseMenuBar(onExit: () -> Unit) {
     }
 }
 
-// The sidebar + detail shell: the sidebar selection chooses which section body fills the center.
+// The sidebar + detail shell, navigated by an androidx.navigation3 back stack.
+//
+// The back stack is the state and the sidebar is a view of it: the selected row is derived from the top
+// key, and picking a row pushes. Only the top entry is composed, which is what lets the same section be
+// visited twice - "Components -> Table -> Components" puts one contentKey on the stack twice, and a
+// display that composed every entry would fail on it.
 @Composable
 internal fun ShowcaseShell() {
-    var selected by remember { mutableIntStateOf(0) }
+    val backStack = remember { mutableStateListOf(SectionKey(showcaseSections.first().title)) }
+    val entries =
+        rememberDecoratedNavEntries(
+            backStack = backStack,
+            entryDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator()),
+            entryProvider =
+                entryProvider {
+                    entry<SectionKey> { key -> showcaseSections.first { it.title == key.title }.body() }
+                },
+        )
+    val current = backStack.last().title
     BorderPanel(
         modifier = SwingModifier.emptyBorder(12),
     ) {
         ScrollPane(modifier = SwingModifier.west().preferredSize(Dimension(180, 0))) {
             ListBox(
                 items = showcaseSections.map { it.title },
-                selectedIndices = setOf(selected),
-                onSelectionChange = { indices -> indices.firstOrNull()?.let { selected = it } },
+                selectedIndices = setOf(showcaseSections.indexOfFirst { it.title == current }),
+                // Driving the selection from the back stack does not re-enter this callback, so a pop
+                // moves the highlight without pushing the row it lands on.
+                onSelectionChange = { indices ->
+                    indices.firstOrNull()?.let { backStack += SectionKey(showcaseSections[it].title) }
+                },
                 selectionMode = ListSelectionModel.SINGLE_SELECTION,
                 visibleRowCount = showcaseSections.size,
                 modifier = SwingModifier.viewport().accessibleName("Sections"),
             )
         }
-        // A section body names no region, so BorderLayout gives it the center by default.
-        showcaseSections.getOrNull(selected)?.body?.invoke()
-        Label(
-            "Section: ${showcaseSections.getOrNull(selected)?.title ?: "-"}",
-            modifier = SwingModifier.south().horizontalAlignment(SwingConstants.LEADING),
-        )
+        // The entry names no region, so BorderLayout gives it the center by default.
+        entries.last().Content()
+        FlowPanel(alignment = FlowLayout.LEADING, modifier = SwingModifier.south()) {
+            Button(
+                text = "Back",
+                modifier = SwingModifier.enabled(backStack.size > 1),
+                onClick = { backStack.removeLastOrNull() },
+            )
+            Label("Section: $current")
+        }
     }
 }
+
+// The back stack's key type. A section is identified by its title, so the key is comparable and its
+// toString - which is what nav3 derives contentKey from - is stable across visits.
+internal data class SectionKey(
+    val title: String,
+)
 
 // The canned text File > Open loads into the shared editor document - a stand-in for a real file's
 // contents, so the sample stays self-contained and needs no file on disk.

--- a/samples/widgets-gallery/src/test/kotlin/org/jetbrains/compose/swing/samples/widgets/navigation/ShowcaseShellNavigationTest.kt
+++ b/samples/widgets-gallery/src/test/kotlin/org/jetbrains/compose/swing/samples/widgets/navigation/ShowcaseShellNavigationTest.kt
@@ -1,0 +1,102 @@
+package org.jetbrains.compose.swing.samples.widgets.navigation
+
+import org.jetbrains.compose.swing.samples.widgets.ShowcaseShell
+import org.jetbrains.compose.swing.samples.widgets.onSectionList
+import org.jetbrains.compose.swing.samples.widgets.showcaseSections
+import org.jetbrains.compose.swing.test.ComposeSwingTest
+import org.jetbrains.compose.swing.test.onAllNodesOfType
+import org.jetbrains.compose.swing.test.runComposeSwingTest
+import javax.swing.JList
+import javax.swing.JTextField
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The gallery shell as it is actually navigated: an `androidx.navigation3` back stack behind a sidebar,
+ * a detail region showing only the top entry, and a Back button popping it.
+ *
+ * These pin the behaviours the back stack adds over a plain index - history, a revisit, and the sidebar
+ * following a pop - and the one it takes away, which is the live state of the section left behind.
+ */
+class ShowcaseShellNavigationTest {
+    private companion object {
+        const val COMPONENTS = "Components"
+        const val TABLE = "Table"
+        const val TREE = "Tree"
+    }
+
+    private suspend fun ComposeSwingTest.select(title: String) {
+        onSectionList().fetch<JList<*>>().selectedIndex = showcaseSections.indexOfFirst { it.title == title }
+        awaitIdle()
+    }
+
+    private fun ComposeSwingTest.selectedSection(): String =
+        showcaseSections[onSectionList().fetch<JList<*>>().selectedIndex].title
+
+    @Test
+    fun backReturnsToThePreviousSectionAndTheSidebarFollows() =
+        runComposeSwingTest {
+            setContent { ShowcaseShell() }
+
+            assertEquals(showcaseSections.first().title, selectedSection())
+            onNodeWithText("Back").assertIsNotEnabled()
+
+            select(TABLE)
+            onNodeWithText("Section: $TABLE", substring = true).assertExists()
+            onNodeWithText("Back").assertIsEnabled()
+
+            select(TREE)
+            onNodeWithText("Back").performClick()
+            awaitIdle()
+
+            onNodeWithText("Section: $TABLE", substring = true).assertExists()
+            assertEquals(TABLE, selectedSection(), "the sidebar did not follow the pop")
+        }
+
+    /**
+     * A revisit puts one `contentKey` on the stack twice - the case a display composing every entry
+     * fails on, and the reason only the top entry is composed.
+     */
+    @Test
+    fun aSectionCanBeVisitedTwiceOnOneStack() =
+        runComposeSwingTest {
+            setContent { ShowcaseShell() }
+
+            select(TABLE)
+            select(COMPONENTS)
+            awaitIdle()
+
+            assertTrue(takeCallerFailures().isEmpty(), "revisiting a section failed the composition")
+            onNodeWithText("Section: $COMPONENTS", substring = true).assertExists()
+
+            onNodeWithText("Back").performClick()
+            awaitIdle()
+            onNodeWithText("Section: $TABLE", substring = true).assertExists()
+        }
+
+    /**
+     * Navigating away drops the outgoing section's declaration, so its components are removed and
+     * rebuilt on return. What the user typed into one is gone - the cost the back stack imposes, and
+     * the reason a screen with state worth keeping has to hoist it or write it with `rememberSaveable`.
+     */
+    @Test
+    fun aSectionSLiveWidgetStateDoesNotSurviveNavigation() =
+        runComposeSwingTest {
+            setContent { ShowcaseShell() }
+
+            select(COMPONENTS)
+            val field = onAllNodesOfType<JTextField>().fetchAll().first { it.isEditable }
+            val typed = field.text + "-edited"
+            field.text = typed
+            awaitIdle()
+
+            select(TABLE)
+            onNodeWithText("Back").performClick()
+            awaitIdle()
+
+            val afterReturn = onAllNodesOfType<JTextField>().fetchAll().first { it.isEditable }
+            assertTrue(afterReturn !== field, "the section's component survived navigation")
+            assertTrue(afterReturn.text != typed, "the typed text survived, so the section was not rebuilt")
+        }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ dependencyResolutionManagement {
     }
 }
 
+include(":samples:docs")
 include(":samples:todo-app")
 include(":samples:widgets-gallery")
 include(":swing-ui")

--- a/swing-ui-test/build.gradle.kts
+++ b/swing-ui-test/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("buildsrc.convention.kotlin-quality")
     id("buildsrc.convention.publishing")
     id("buildsrc.convention.jacoco-coverage")
+    id("buildsrc.convention.window-system-lock")
 }
 
 kotlin {

--- a/swing-ui/build.gradle.kts
+++ b/swing-ui/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("buildsrc.convention.kotlin-quality")
     id("buildsrc.convention.publishing")
     id("buildsrc.convention.jacoco-coverage")
+    id("buildsrc.convention.window-system-lock")
 }
 
 kotlin {
@@ -76,7 +77,42 @@ jacocoCoverage {
     branchMinimum.set("0.80".toBigDecimal())
 }
 
+// The tag carried by org.jetbrains.compose.swing.ExclusiveWindowSystem, whose KDoc says what the split
+// separates and why. Splitting on a tag rather than on package or name keeps the requirement stated at
+// the test that has it.
+val exclusiveWindowSystemTag = "exclusive-window-system"
+
+tasks.test {
+    useJUnitPlatform { excludeTags(exclusiveWindowSystemTag) }
+    // These tests show real windows too, but assert nothing about which window the window system is
+    // attending to, so several can run at once. The parallelism has to come from forked JVMs: every test
+    // body runs on the event dispatch thread, one thread per JVM, so running them as concurrent threads
+    // of a single JVM would serialize on that thread anyway. Half the cores leaves the Gradle daemon and
+    // the tasks running alongside room of their own.
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+}
+
+val exclusiveWindowSystemTest by tasks.registering(Test::class) {
+    description = "Runs the tests that need the window system's undivided attention, one at a time."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    val testSourceSet = sourceSets.test.get()
+    testClassesDirs = testSourceSet.output.classesDirs
+    classpath = testSourceSet.runtimeClasspath
+    useJUnitPlatform { includeTags(exclusiveWindowSystemTag) }
+    // Keeping the two apart is the window-system lock's doing; this only settles the order, so the fast
+    // parallel task is done showing windows before this one starts asserting on which window is focused.
+    shouldRunAfter(tasks.test)
+}
+
+tasks.check {
+    dependsOn(exclusiveWindowSystemTest)
+}
+
 tasks.withType<Test>().configureEach {
+    // The tag the tests are split on, handed to the tests themselves so one of them can assert that the
+    // two spellings still agree. A tag only this file knew would silently stop matching any test: the
+    // task filtering on it would run nothing, which passes.
+    systemProperty("compose.swing.test.exclusiveWindowSystemTag", exclusiveWindowSystemTag)
     // Hand the resolved Compose compiler plugin jar path to the harness. A FileCollection (not the
     // Configuration itself) is captured so the task stays configuration-cache compatible, and it is read
     // lazily inside the provider so configuration of unrelated tasks never forces resolution.

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/ExclusiveWindowSystem.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/ExclusiveWindowSystem.kt
@@ -1,0 +1,29 @@
+package org.jetbrains.compose.swing
+
+import org.junit.jupiter.api.Tag
+
+/**
+ * Declares that a test class's outcome depends on which of this process's windows the window system is
+ * attending to: whether a window is the focused one, or whether it has been minimized.
+ *
+ * That is a single, machine-wide state, so two such tests cannot run at the same time - one asking to be
+ * focused takes the focus away from the other, which then reports a withheld capability and skips. A skip
+ * is silent lost coverage rather than a failure, so the separation is a correctness measure, not a
+ * performance one.
+ *
+ * Tests carrying this tag run in a test task of their own that runs them one at a time. Everything else
+ * runs across parallel JVMs: those tests realize and show real windows too, and the focus that moves
+ * between them is nothing they assert on.
+ *
+ * The tag goes on the class, so a class holding both kinds of case runs entirely under the serial task.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag(EXCLUSIVE_WINDOW_SYSTEM_TAG)
+internal annotation class ExclusiveWindowSystem
+
+/**
+ * The name the build's test-task split filters on: one task excludes it, the other includes it. The
+ * build declares the same literal, which is why it reads as a name rather than a detail of this file.
+ */
+internal const val EXCLUSIVE_WINDOW_SYSTEM_TAG: String = "exclusive-window-system"

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/ExclusiveWindowSystemTagTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/ExclusiveWindowSystemTagTest.kt
@@ -1,0 +1,26 @@
+package org.jetbrains.compose.swing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Holds the build's half of the test split to the tag [ExclusiveWindowSystem] actually carries.
+ *
+ * The two are written separately - once here in Kotlin, once as a literal in the module's build script -
+ * and nothing but this test connects them. Left unconnected they fail in the one direction that reports
+ * nothing: the task filtering for a tag no test carries selects an empty suite, which passes, while every
+ * test meant to run alone falls back into the parallel task and skips on a window system it now shares.
+ *
+ * This test is deliberately untagged, so it runs in that parallel task on every build.
+ */
+class ExclusiveWindowSystemTagTest {
+    @Test
+    fun theBuildSplitsTheSuiteOnTheTagTheAnnotationCarries() {
+        val fromBuild = System.getProperty(TAG_PROPERTY)
+        assertNotNull(fromBuild, "the build must hand every test task the tag it splits on, as $TAG_PROPERTY")
+        assertEquals(EXCLUSIVE_WINDOW_SYSTEM_TAG, fromBuild, "the build splits on a tag no test carries")
+    }
+}
+
+private const val TAG_PROPERTY = "compose.swing.test.exclusiveWindowSystemTag"

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/FrameIconifyCapability.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/FrameIconifyCapability.kt
@@ -24,6 +24,8 @@ import kotlin.time.TimeSource
  * Minimizing a window at all is a capability a host may withhold, not a defect: a frame the host never minimizes skips
  * here; a minimized frame whose content did not follow it into the matching lifecycle state fails below.
  *
+ * A class calling this carries [ExclusiveWindowSystem].
+ *
  * Call this inside `runComposeSwingTest`: waiting here suspends and hands the event dispatch thread
  * back, which is what lets the notification arrive.
  */

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/KeyboardFocusCapability.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/KeyboardFocusCapability.kt
@@ -28,6 +28,8 @@ import kotlin.time.TimeSource
  * probe window of its own, while being focused is a fact about one window at one moment. A test that
  * needs the window it opened focused waits for that window with [assumeWindowBecomesFocused].
  *
+ * A class calling this carries [ExclusiveWindowSystem].
+ *
  * Call this on the test method, before `runComposeSwingTest`: the probe waits for a window-system
  * notification, which cannot arrive while the event dispatch thread is blocked inside the test body.
  */
@@ -46,6 +48,8 @@ internal fun assumeKeyboardFocusIsPossible() {
  * keyboard is the library's own doing, so each test asserts that for itself below this gate, with plain
  * assertions: a window the system never focuses skips, and a focused window whose keyboard went to the
  * wrong component fails.
+ *
+ * A class calling this carries [ExclusiveWindowSystem].
  *
  * Call this inside `runComposeSwingTest`: waiting here suspends and hands the event dispatch thread back,
  * which is what lets the activation the window system posts arrive.

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/KeyboardFocusGateTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/KeyboardFocusGateTest.kt
@@ -24,6 +24,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * The windows used here declare themselves unfocusable, which the window system declines to focus on every
  * host, so what the gate does at its deadline is observable whether or not this host grants focus at all.
  */
+@ExclusiveWindowSystem
 class KeyboardFocusGateTest {
     @Test
     fun aWindowTheSystemNeverFocusesSkipsTheTestInsteadOfFailingIt() {

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/text/FormattedTextFieldFocusTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/text/FormattedTextFieldFocusTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.ExclusiveWindowSystem
 import org.jetbrains.compose.swing.assumeKeyboardFocusIsPossible
 import org.jetbrains.compose.swing.assumeWindowBecomesFocused
 import org.jetbrains.compose.swing.components.layout.Column
@@ -32,6 +33,7 @@ import kotlin.test.assertTrue
  * Losing the keyboard is what triggers the commit, so these run only where the window system grants
  * focus to this process's windows.
  */
+@ExclusiveWindowSystem
 class FormattedTextFieldFocusTest {
     private fun integerFactory(): DefaultFormatterFactory {
         val formatter = NumberFormatter()

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/CompositionLifecycleTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/CompositionLifecycleTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.jetbrains.compose.swing.ExclusiveWindowSystem
 import org.jetbrains.compose.swing.assumeFrameDeiconifies
 import org.jetbrains.compose.swing.assumeFrameIconifies
 import org.jetbrains.compose.swing.assumeKeyboardFocusIsPossible
@@ -73,6 +74,7 @@ import kotlin.time.TimeSource
  * a composition mounted through `runComposeSwingTest` reports CREATED however long it is driven. A case
  * that observes STARTED or RESUMED therefore mounts into a real window of its own and shows it.
  */
+@ExclusiveWindowSystem
 class CompositionLifecycleTest {
     @Test
     fun contentThatHangsOffNoWindowReportsCreated() = runSwingTest {

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/interaction/FocusRequesterTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/interaction/FocusRequesterTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.ExclusiveWindowSystem
 import org.jetbrains.compose.swing.assumeKeyboardFocusIsPossible
 import org.jetbrains.compose.swing.assumeWindowBecomesFocused
 import org.jetbrains.compose.swing.components.layout.Column
@@ -42,6 +43,7 @@ import kotlin.test.assertTrue
  * request must *not* do is asserted on the request itself, which answers whether anything was asked for
  * without consulting the window system at all.
  */
+@ExclusiveWindowSystem
 class FocusRequesterTest {
     @Test
     fun aRequesterBoundToNothingRefusesTheRequest() = runComposeSwingTest {

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/interaction/InitialFocusTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/interaction/InitialFocusTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.compose.swing.modifier.interaction
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.ExclusiveWindowSystem
 import org.jetbrains.compose.swing.assumeKeyboardFocusIsPossible
 import org.jetbrains.compose.swing.assumeWindowBecomesFocused
 import org.jetbrains.compose.swing.components.layout.Column
@@ -43,6 +44,7 @@ import kotlin.test.assertTrue
  * case that asserts a declaration was *not* acted on names the component that must not have taken the
  * focus, which reads the same whichever of the two the property is reporting.
  */
+@ExclusiveWindowSystem
 class InitialFocusTest {
     @Test
     fun theDeclarationLeavesTheComponentsOwnFocusabilityAlone() = runComposeSwingTest {

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/interaction/OnAcceptModifierTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/interaction/OnAcceptModifierTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.compose.swing.modifier.interaction
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.ExclusiveWindowSystem
 import org.jetbrains.compose.swing.assumeKeyboardFocusIsPossible
 import org.jetbrains.compose.swing.assumeWindowBecomesFocused
 import org.jetbrains.compose.swing.components.Label
@@ -29,6 +30,7 @@ import kotlin.test.assertTrue
  * The key-binding case needs a field that actually holds the keyboard: the field's Enter action asks the
  * platform which text component is focused, so it runs only where the window system grants focus.
  */
+@ExclusiveWindowSystem
 class OnAcceptModifierTest {
     @Test
     fun theFieldsActionEventRunsTheCallback() = runComposeSwingTest {


### PR DESCRIPTION
The `README` quick start did not compile: `BorderPanel` had replaced the receiver DSL it used, and no snippet here was ever compiled. This branch fixes it and removes the condition that let it rot.
- Knit merges the marked Kotlin blocks in `README.md` and `docs/` into a new `samples/docs` module, which compiles 34 examples. Nothing generated is committed.
- Dokka renders one aggregated API reference, deployed to GitHub Pages on every push to `master`.
- Releases are created with `--draft`, and `--prerelease` when a suffix names one.
- `:swing-ui` splits its suite: only classes tagged `ExclusiveWindowSystem` run one at a time.
- The gallery sample drives its screens from an `androidx.navigation3` back stack.