### PR TITLE
Fix how a declaration reaches its widget

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,8 +33,10 @@ whose disposal the caller owns - an integration-level entry point, opted into wi
 container is attached to, which is what serves a container built to be read rather than shown.
 Everything mounted inside such a container joins the same parent: a `setContent` naming no parent of
 its own on a container hanging under that island resolves to the composition the island was given
-rather than to the window's. Such a container joins the composition of the window it is in should it
-later be added to one, so a window's content still recomposes on one recomposer and one frame clock.
+rather than to the window's. A container given a window's own scope joins the composition of the
+window it is in should it later be added to another, so a window's content still recomposes on one
+recomposer and one frame clock. A container given a runtime of its own is kept on that runtime
+instead: a move brings only the window its content reads up to date.
 
 Content reads a `LifecycleOwner` through `LocalLifecycleOwner`, shared by everything that content
 hosts - popups, menus, overlays. A mount resolves that owner from where its container hangs in the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,13 +63,36 @@ behaves as it does on any Compose target.
 
 ---
 
-## Pacing with a frame clock
+## Two cadences: changes and animation time
 
-Each top-level composition is paced by its own frame clock running at a display-like cadence on the
-EDT. `withFrameNanos`, the animation APIs built on it, and recomposition are all driven by this
-clock. The clock advances only while something is waiting for a frame, so an idle window does no
-per-frame work while an animating one advances at a steady rate. Time-based work in separate
-windows is independent.
+A change and the passage of animation time advance at rates of their own.
+
+A change follows the event queue. Writing state invalidates the scopes that read it, and the pass that
+recomposes and applies those scopes is dispatched as an event of its own, so a declared change reaches
+its widget a handful of event-dispatch cycles after the event that made it rather than at the next tick
+of a frame cadence. It costs one pass per event rather than one per write: the pass is dispatched only
+once the Swing event that made the writes has returned, so a listener writing ten properties still
+costs a single pass.
+
+That is not a setter. A setter is on its widget for the very next statement; a declared write is never
+visible inside the event that made it, and code that has to see the result waits for a later cycle.
+
+A widget the user can move themselves settles on this cadence too, and Swing's own ordering shows
+through. Swing applies the move first: a click flips `JCheckBox.isSelected` and queues the repaint
+before the action listener that reports the click runs. The put-back is a later event, so it cannot
+precede a repaint already queued, and the widget is painted once holding the value the caller
+rejected. A handful of event-dispatch cycles keep that paint inside a single display refresh
+interval, so the rejected value is not scanned out. Ordering the put-back ahead of the paint would mean holding back
+every paint in the process until the composition had settled.
+
+`withFrameNanos`, and the animation APIs built on it, advance at a nominal cadence instead. Content
+mounted under a window takes that cadence from the display the window is on and follows it across
+displays; a composition standing in no window keeps a fixed nominal rate. The cadence is best-effort
+wall-clock timing rather than vsync, and it runs only while something is awaiting a frame, so an idle
+window does no per-frame work while an animating one advances a step at a time. A change landing
+mid-animation does not wait for the animation's next frame - it applies on the cycles that follow the
+event that made it - and leaves the animation exactly where it was, so the animation neither skips a
+step nor takes an extra one. Time-based work in separate windows is independent.
 
 ---
 
@@ -307,9 +330,11 @@ Button(text = "Clicks: $count", onClick = { count++ })
 
 1. The user clicks. Swing fires the button's listener on the EDT and the current `onClick` runs
    `count++`.
-2. Writing the state is observed and the scope that read `count` is scheduled to recompose.
-3. On the next frame the invalidated scope re-executes and recomputes the label; the stable listener
-   is left in place.
+2. Writing the state is observed and the scope that read `count` is scheduled to recompose. The
+   listener returns with the button still showing the old label.
+3. The notification, the recomposer waking and the frame it then asks for each travel as an event, so
+   a handful of event-dispatch cycles later the invalidated scope re-executes and recomputes the
+   label; the stable listener is left in place.
 4. The change is applied to the live button, and its container is marked for layout.
 5. Once the change pass completes, that container is laid out and repainted once, and the new label
    is on screen.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,9 +30,11 @@ own scope. A scope of its own comes from a runtime created for a component with
 whose disposal the caller owns - an integration-level entry point, opted into with
 `@OptIn(InternalSwingUiApi::class)`.
 `container.setContent(parent) { ... }` then composes on the call, whatever the
-container is attached to, which is what serves a container built to be read rather than shown. Such
-a container joins the composition of the window it is in should it later be added to one, so a
-window's content still recomposes on one recomposer and one frame clock.
+container is attached to, which is what serves a container built to be read rather than shown.
+Everything mounted inside such a container joins the same parent: a `setContent` naming no parent of
+its own on a container hanging under that island resolves to the composition the island was given
+rather than to the window's. Such a container joins the composition of the window it is in should it
+later be added to one, so a window's content still recomposes on one recomposer and one frame clock.
 
 Content reads a `LifecycleOwner` through `LocalLifecycleOwner`, shared by everything that content
 hosts - popups, menus, overlays. A mount resolves that owner from where its container hangs in the

--- a/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/components/ComponentsSection.kt
+++ b/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/components/ComponentsSection.kt
@@ -54,6 +54,7 @@ internal fun ComponentsSection() {
         PasswordCard()
         PasswordStateCard()
         ToggleCard()
+        UnadoptedMoveCard()
         ChoiceCard()
         RangeCard()
         ListBoxCard()
@@ -189,6 +190,47 @@ private fun ColumnScope.ToggleCard() {
             RadioButton(text = "High", selected = choice == 2, onSelectedChange = { if (it) choice = 2 })
         }
         Label("Priority index: $choice")
+    }
+}
+
+@Composable
+private fun ColumnScope.UnadoptedMoveCard() {
+    ExampleCard("A move the caller does not adopt") {
+        var signedIn by remember { mutableStateOf(false) }
+        var syncing by remember { mutableStateOf(false) }
+        var refused by remember { mutableIntStateOf(0) }
+
+        CheckBox(text = "Signed in", checked = signedIn, onCheckedChange = { signedIn = it })
+        // Adopted only while signed in. Swing selects the box on the click, before the callback is
+        // told about it, so a refused click leaves it selected until the pass that follows writes
+        // this declaration back over it.
+        CheckBox(
+            text = "Sync in the background",
+            checked = syncing,
+            onCheckedChange = { if (signedIn) syncing = it else refused++ },
+        )
+        Label(
+            if (signedIn) {
+                "Syncing is ${if (syncing) "on" else "off"}"
+            } else {
+                "Sign in to change this - refused $refused click(s)"
+            },
+        )
+
+        var year by remember { mutableStateOf("2026") }
+        var lastRefusedEdit by remember { mutableStateOf<String?>(null) }
+        TextField(
+            value = year,
+            onValueChange = { edited ->
+                if (edited.all(Char::isDigit)) {
+                    year = edited
+                    lastRefusedEdit = null
+                } else {
+                    lastRefusedEdit = edited
+                }
+            },
+        )
+        Label(lastRefusedEdit?.let { "\"$it\" is not a year - the field shows $year" } ?: "Digits only")
     }
 }
 

--- a/samples/widgets-gallery/src/test/kotlin/org/jetbrains/compose/swing/samples/widgets/components/UnadoptedMoveCardTest.kt
+++ b/samples/widgets-gallery/src/test/kotlin/org/jetbrains/compose/swing/samples/widgets/components/UnadoptedMoveCardTest.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.compose.swing.samples.widgets.components
+
+import org.jetbrains.compose.swing.samples.widgets.openSection
+import org.jetbrains.compose.swing.test.SwingMatcher
+import org.jetbrains.compose.swing.test.runComposeSwingTest
+import kotlin.test.Test
+
+class UnadoptedMoveCardTest {
+    @Test
+    fun aClickTheCardDoesNotAdoptLeavesTheBoxClear() =
+        runComposeSwingTest {
+            openSection("Components")
+
+            onNodeWithText("Sync in the background").performClick()
+            onNodeWithText("Sync in the background").assert(SwingMatcher.isSelected(false))
+            onNodeWithText("refused 1 click(s)", substring = true).assertExists()
+
+            onNodeWithText("Signed in").performClick()
+            onNodeWithText("Sync in the background").performClick()
+            onNodeWithText("Sync in the background").assert(SwingMatcher.isSelected())
+            onNodeWithText("Syncing is on", substring = true).assertExists()
+        }
+}

--- a/swing-ui-test/src/main/kotlin/org/jetbrains/compose/swing/test/MainTestClock.kt
+++ b/swing-ui-test/src/main/kotlin/org/jetbrains/compose/swing/test/MainTestClock.kt
@@ -15,8 +15,8 @@ import kotlin.time.Duration.Companion.seconds
  *
  * This clock governs only [ComposeSwingTest]'s own off-screen composition. Content composed under a
  * real [org.jetbrains.compose.swing.window.Window] or [org.jetbrains.compose.swing.window.Dialog]
- * recomposes on that window's own recomposer, paced by its own display's refresh rate - this clock
- * has no effect on it.
+ * runs on that window's own recomposer, whose frame-driven work is paced by the display that window
+ * is on - this clock has no effect on it.
  */
 public sealed interface MainTestClock {
     /**

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/SetContent.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/SetContent.kt
@@ -38,7 +38,9 @@ import javax.swing.RootPaneContainer
  * of its own on a container hanging under this one resolves to [parent] rather than to the composition
  * its window shares. The caller owns what they pass: disposing the returned handle disposes this
  * island's composition and leaves [parent] running. A container that later ends up in a different
- * window joins the composition of the window it is then in, recreating this island's content there.
+ * window joins the composition of the window it is then in, recreating this island's content there -
+ * unless [parent] is a runtime of the caller's own, which the content is kept on. A move then brings only
+ * the window the content reads up to date, and everything the content remembered survives it.
  *
  * The content reads its [LocalWindow][org.jetbrains.compose.swing.window.LocalWindow] from the
  * composition it joins, and the window this container is in wherever that composition names none.

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/SetContent.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/SetContent.kt
@@ -34,9 +34,11 @@ import javax.swing.RootPaneContainer
  *
  * A [parent] drives the composition instead, and the content composes **on this call**, whatever the
  * container is attached to - which is what reaches a container that is built to be read rather than
- * shown. The caller owns what they pass: disposing the returned handle disposes this island's
- * composition and leaves [parent] running. A container that later ends up in a different window joins
- * the composition of the window it is then in, recreating this island's content there.
+ * shown. Everything mounted inside this island joins [parent] as well: a `setContent` naming no parent
+ * of its own on a container hanging under this one resolves to [parent] rather than to the composition
+ * its window shares. The caller owns what they pass: disposing the returned handle disposes this
+ * island's composition and leaves [parent] running. A container that later ends up in a different
+ * window joins the composition of the window it is then in, recreating this island's content there.
  *
  * The content reads its [LocalWindow][org.jetbrains.compose.swing.window.LocalWindow] from the
  * composition it joins, and the window this container is in wherever that composition names none.
@@ -64,8 +66,9 @@ import javax.swing.RootPaneContainer
  *
  * Must be called on the Event Dispatch Thread.
  *
- * @param parent the composition context this content joins and shares the recomposition scope of.
- *   Defaults to `null`, meaning the composition the container's own place in the Swing tree resolves to.
+ * @param parent the composition context this content joins and shares the recomposition scope of, and
+ *   the one anything mounted inside this island joins. Defaults to `null`, meaning the composition the
+ *   container's own place in the Swing tree resolves to.
  * @param content the composable content to set
  * @return a [DisposableHandle] that disposes this island's composition when invoked (or, if the mount
  *   has not happened yet, cancels it).

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/ComboBox.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/ComboBox.kt
@@ -62,15 +62,18 @@ public fun <T> ComboBox(
     maximumRowCount: Int = 8,
     itemContent: (@Composable ListItemScope.(item: T) -> Unit)? = null,
 ) {
+    // Reading the items while composing is what makes this composition one of their readers, so a caller
+    // that keeps them in a snapshot list and mutates it in place invalidates this combo box.
+    val declaredItems = items.toList()
     val applied = rememberAppliedValue(selectedItem)
-    val settled = rememberSelectionReader(items)
+    val settled = rememberSelectionReader(declaredItems)
     ComboBoxNode(
         modifier = modifier.onSelectionAction(applied, settled, onSelectionChange, onValueCommit),
         editable = editable,
         maximumRowCount = maximumRowCount,
         itemContent = itemContent,
     ) {
-        installItems(items, selectedItem, applied)
+        installItems(declaredItems, selectedItem, applied)
     }
 }
 
@@ -104,8 +107,11 @@ public fun <T> ComboBox(
     maximumRowCount: Int = 8,
     itemContent: (@Composable ListItemScope.(item: T) -> Unit)? = null,
 ) {
+    // Reading the items while composing is what makes this composition one of their readers, so a caller
+    // that keeps them in a snapshot list and mutates it in place invalidates this combo box.
+    val declaredItems = items.toList()
     val applied = rememberAppliedValue(selectedItem)
-    val settled = rememberSelectionReader(items)
+    val settled = rememberSelectionReader(declaredItems)
     // The caller's listener is attached as-is, and is the only action listener on the combo box. The
     // mirror rides the item-selection channel instead, so the declared selection still settles against
     // wherever the combo box lands, whether that is the user's own choice or the caller's own write back.
@@ -126,7 +132,7 @@ public fun <T> ComboBox(
         maximumRowCount = maximumRowCount,
         itemContent = itemContent,
     ) {
-        installItems(items, selectedItem, applied)
+        installItems(declaredItems, selectedItem, applied)
     }
 }
 
@@ -239,6 +245,10 @@ private fun <T> ComboBoxNode(
 
 /**
  * Declares [items] and [selectedItem] on the node both items-family [ComboBox] overloads render.
+ *
+ * [items] must be a list no caller holds: it is what the next pass's items are compared against to decide
+ * whether the combo box needs a new model, and a list the caller can mutate in place would be compared
+ * against itself and never differ.
  */
 private fun <T> SwingNodeUpdater<JComboBox<T>>.installItems(
     items: List<T>,

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/Spinner.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/Spinner.kt
@@ -209,12 +209,17 @@ public fun <T : Any> Spinner(
 ) {
     val applied = rememberAppliedValue<Any?>(value)
 
+    // The items this composition declares, read while composing: a caller may keep the items in a snapshot
+    // list and mutate that list in place, and reading them here is what makes this composition one of the
+    // list's readers, so such a mutation invalidates the spinner and the new items reach the model.
+    val declaredItems = items.toList()
+
     // Every value the channel carries comes from the ListSpinnerModel below, which reports only what its
-    // own items hold - the caller's List<T> - so the model can hand back nothing that is not a T. The
-    // type is lost only because Swing's SpinnerModel types its value as Any?.
+    // own items hold - the caller's List<T>, copied - so the model can hand back nothing that is not a T.
+    // The type is lost only because Swing's SpinnerModel types its value as Any?.
     @Suppress("UNCHECKED_CAST")
     val channel = rememberSpinnerValueChannel(applied) { onValueChange(it as T) }
-    val model = remember { ListSpinnerModel(items).also { it.setValue(value) } }
+    val model = remember { ListSpinnerModel(declaredItems).also { it.setValue(value) } }
 
     SpinnerNode(
         model = model,
@@ -222,7 +227,7 @@ public fun <T : Any> Spinner(
         format = null,
         editor = editor,
     ) {
-        set(items) { applied.write { model.items = it } }
+        set(declaredItems) { applied.write { model.items = it } }
         declare(value, applied, JSpinner::getValue, JSpinner::setValue) { settled -> channel.settledOn(settled) }
     }
 }
@@ -336,7 +341,13 @@ private class ListSpinnerModel<T>(
 ) : AbstractSpinnerModel() {
     private var index = 0
 
-    /** Assigning a new list moves the selection to its head. */
+    /**
+     * The items the spinner steps through. Assigning a new list moves the selection to its head.
+     *
+     * Every read the model answers - value, neighbors, the index a written value lands on - comes from
+     * this list, so it must be one no caller holds: what the model reports is then always what the
+     * spinner was last told, and a read during paint touches no caller state.
+     */
     var items: List<T> = items
         set(value) {
             field = value

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ListBox.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ListBox.kt
@@ -140,6 +140,12 @@ public fun <T> ListBox(
     fixedCellHeight: Int = -1,
     itemContent: (@Composable ListItemScope.(item: T) -> Unit)? = null,
 ) {
+    // The items this composition declares, read while composing: a caller may keep the items in a snapshot
+    // list and mutate that list in place, and reading them here is what makes this composition one of the
+    // list's readers, so such a mutation invalidates the list box and the new items reach the model. Held
+    // as a copy of its own, it is also what the next pass's items are compared against - a comparison
+    // against the caller's own list would be that list against itself, and never find a difference.
+    val declaredItems = items.toList()
     ListBoxNode(
         listSelectionListener = listSelectionListener,
         modifier = modifier,
@@ -152,7 +158,7 @@ public fun <T> ListBox(
         fixedCellHeight = fixedCellHeight,
         itemContent = itemContent,
     ) { applied ->
-        set(items) { newItems ->
+        set(declaredItems) { newItems ->
             installContent(applied, selectedIndices, listSelectionListener) { setListData(Vector(newItems)) }
         }
     }

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/Table.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/Table.kt
@@ -206,6 +206,10 @@ public fun <R> Table(
     tableColumnModelListener: TableColumnModelListener? = null,
     block: TableScope<R>.() -> Unit,
 ) {
+    // The rows this composition declares, read while composing: a caller may keep the rows in a snapshot
+    // list and mutate that list in place, and reading them here is what makes this composition one of the
+    // list's readers, so such a mutation invalidates the table and the new rows reach the model.
+    val declaredRows = rows.toList()
     val columns = TableScopeImpl<R>().apply(block).columns
     // The model this composition fills. It is handed to the factory so the table is built already
     // showing it, rather than a default model briefly standing in before the update block's own
@@ -249,7 +253,7 @@ public fun <R> Table(
             fun swapInDeclaredContent() {
                 sortChannel.unbindFrom(table, model)
                 table.model = model
-                model.refresh(rows, columns)
+                model.refresh(declaredRows, columns)
                 appliedColumn.write { table.applyDeclaredColumnWidths(columns) }
             }
 

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/TableColumns.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/TableColumns.kt
@@ -226,28 +226,45 @@ internal class TableScopeImpl<R> : TableScope<R> {
 }
 
 /**
- * The [AbstractTableModel] backing a [Table]: it presents [rows] through the [columns]' value
- * extractors and routes a committed cell edit to the edited column's `onCellEdit`.
+ * The [AbstractTableModel] backing a [Table]: it presents the rows it was last given through the
+ * [columns]' value extractors and routes a committed cell edit to the edited column's `onCellEdit`.
+ *
+ * The model answers every read - row count, cell value, editability - from the rows it was last given,
+ * which are held apart from any list the caller keeps, so what it reports is always what the table was
+ * last told, and a read during paint touches no caller state. An in-place edit of the caller's list never
+ * writes to them, so the displayed value only changes once the caller updates the backing state and a new
+ * composition supplies fresh rows.
  *
  * [refresh] takes the latest rows and columns on every recomposition and fires the *narrowest*
  * change event the difference warrants: a structure change only when the column shape (count,
  * headers, classes, editability, cell bodies) differs, a data change when only the rows differ, and
  * nothing at all when neither did, so a recomposition that changed no data leaves the table entirely alone.
- * An in-place edit never mutates [rows] itself, so the displayed value only changes once the caller
- * updates the backing state and a new composition supplies fresh rows.
  */
 internal class ColumnsTableModel<R> : AbstractTableModel() {
+    /**
+     * The rows the model last reported to the table, held apart from whatever list the caller declared
+     * them from: a caller may keep that list and mutate it in place, and only rows standing apart from it
+     * can tell the new contents from the old.
+     */
     private var rows: List<R> = emptyList()
     private var columns: List<ColumnDeclaration<R>> = emptyList()
 
-    /** Pushes the latest data into the model, notifying the table of whatever actually changed. */
+    /**
+     * Pushes the latest data into the model, notifying the table of whatever actually changed.
+     *
+     * The incoming [rows] are compared against the ones the model last reported, and a pass that finds
+     * them different adopts the new list along with firing the event.
+     *
+     * The model takes ownership of [rows] and answers every read from it, so the caller has to hand over a
+     * list nothing else can mutate.
+     */
     fun refresh(
         rows: List<R>,
         columns: List<ColumnDeclaration<R>>,
     ) {
         val structureChanged = columnsDiffer(this.columns, columns)
         val rowsChanged = this.rows != rows
-        this.rows = rows
+        if (rowsChanged) this.rows = rows
         this.columns = columns
         when {
             structureChanged -> fireTableStructureChanged()

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/Composition.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/Composition.kt
@@ -18,23 +18,34 @@ import javax.swing.SwingUtilities
 internal const val COMPOSITION_KEY: String = "org.jetbrains.compose.swing.composition"
 
 /**
- * Finds the parent [CompositionContext] by walking the Swing component tree, reading the
- * [COMPOSITION_KEY] client property off each [JComponent].
+ * Finds the parent [CompositionContext] by walking the Swing component tree, reading two things off each
+ * component on the way up: the [COMPOSITION_KEY] client property a host stamps on a [JComponent], and the
+ * context a live `setContent` island on that component composes its content under. The nearest ancestor
+ * that answers wins, so the innermost composition around this component is the one it joins.
  *
- * The walk is self-first: it checks the receiver before its ancestors, so a component stamped with a
- * context (an interop host, or a window root pane) is found by a `setContent` call on that component
- * itself, not only by its descendants.
+ * The client-property walk is self-first: it checks the receiver before its ancestors, so a component
+ * stamped with a context (an interop host, or a window root pane) is found by a `setContent` call on that
+ * component itself, not only by its descendants. An island's context answers for what hangs **inside**
+ * its container, so the receiver's own islands are passed over: a container asks where it hangs, not what
+ * it already carries.
  */
 internal fun Component.findParentCompositionContext(): CompositionContext? {
     var current: Component? = this
     while (current != null) {
-        if (current is JComponent) {
-            (current.getClientProperty(COMPOSITION_KEY) as? CompositionContext)?.let { return it }
-        }
+        current.compositionContextHere(walkStartedAt = this)?.let { return it }
         current = current.parent
     }
     return null
 }
+
+/**
+ * What this component alone answers the walk with: the [COMPOSITION_KEY] stamp a host published on it,
+ * or the context of a live island composing into it. An island answers only for what hangs inside its
+ * container, so the component the walk started at contributes its stamp and none of its islands.
+ */
+private fun Component.compositionContextHere(walkStartedAt: Component): CompositionContext? =
+    (this as? JComponent)?.getClientProperty(COMPOSITION_KEY) as? CompositionContext
+        ?: takeIf { it !== walkStartedAt }?.islandCompositionContextOrNull()
 
 /**
  * Sets [context] as this component's [COMPOSITION_KEY] client property, so descendant `setContent` calls

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SetContentMount.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SetContentMount.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.compose.swing.core
 
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import kotlinx.coroutines.DisposableHandle
@@ -69,7 +70,8 @@ internal fun resolveParentOrNull(component: Component): MountParent? {
 internal fun mountWhenParentResolves(
     component: Component,
     mount: (MountParent, State<Window?>) -> SwingCompositionMount,
-): DisposableHandle = SetContentMountState(component, namedParent = null, mount).also { it.start() }
+): DisposableHandle =
+    SetContentMountState(component, standsOnItsOwnRuntime = false, mount).also { it.start(namedParent = null) }
 
 /**
  * Mounts a `setContent` on [component] under the [namedParent] its caller supplied, composing on the
@@ -82,12 +84,43 @@ internal fun mountUnderNamedParent(
     component: Component,
     namedParent: CompositionContext,
     mount: (MountParent, State<Window?>) -> SwingCompositionMount,
-): DisposableHandle =
-    SetContentMountState(
-        component,
-        MountParent(namedParent, windowOwning(namedParent)),
-        mount,
-    ).also { it.start() }
+): DisposableHandle {
+    check(!namedParent.hasEnded) {
+        "The composition context named for ${component.javaClass.name} belongs to a runtime that has " +
+            "ended, so content composed under it would never recompose. Name a live runtime, or name no " +
+            "parent at all to join the composition this container's own place resolves to."
+    }
+    val parent = MountParent(namedParent, windowOwning(namedParent))
+    // A runtime built for a component is a Recomposer itself, and is owned by no window. A context taken
+    // from inside a live composition is that composition's own child and is torn down with it, and a
+    // window's recomposer ends with its window, so content named either of those follows windows like any
+    // other.
+    val standsOnItsOwnRuntime = namedParent is Recomposer && parent.window == null
+    return SetContentMountState(component, standsOnItsOwnRuntime, mount).also { it.start(parent) }
+}
+
+/**
+ * Whether this context is a runtime that has been cancelled, so nothing composed under it would
+ * recompose again.
+ *
+ * Only a [Recomposer] answers anything here. A context published by a live composition is that
+ * composition's own child and carries no state of its own.
+ *
+ * A cancelled runtime reports [ShuttingDown][Recomposer.State.ShuttingDown] or
+ * [ShutDown][Recomposer.State.ShutDown] whether or not it ever recomposed: cancelling sets the first
+ * from [Idle][Recomposer.State.Idle] or beyond, and the effect job completing sets one of them
+ * otherwise. A runtime that has been built but never started is
+ * [Inactive][Recomposer.State.Inactive], which is a live one.
+ *
+ * The states are named rather than compared by order, so a state added between them cannot change what
+ * this answers.
+ */
+private val CompositionContext.hasEnded: Boolean
+    get() =
+        when ((this as? Recomposer)?.currentState?.value) {
+            Recomposer.State.ShutDown, Recomposer.State.ShuttingDown -> true
+            else -> false
+        }
 
 /**
  * The phase a `setContent` mount is in, whichever way it comes by the parent it composes under.
@@ -124,13 +157,14 @@ private enum class MountPhase { Pending, Mounted, Disposed }
  * with no listener installed.
  *
  * @param component the container the content is composed into, and whose place in the tree is watched.
- * @param namedParent the context the caller named for the content to compose under, or `null` to
- *   resolve one from where [component] hangs in the Swing tree.
+ * @param standsOnItsOwnRuntime whether the content composes on a runtime of its own rather than inside
+ *   another composition. Fixed for the life of the mount, because it states what the caller named rather
+ *   than where the container hangs.
  * @param mount creates and starts the [SwingCompositionMount] under a parent context.
  */
 private class SetContentMountState(
     private val component: Component,
-    private val namedParent: MountParent?,
+    private val standsOnItsOwnRuntime: Boolean,
     private val mount: (MountParent, State<Window?>) -> SwingCompositionMount,
 ) : DisposableHandle {
     private var phase = MountPhase.Pending
@@ -167,8 +201,12 @@ private class SetContentMountState(
      * A container already carrying a live island is refused. Only a live one stands in the way: a
      * container whose island was disposed takes content again, and one whose mount is still waiting for
      * a parent answers nothing yet.
+     *
+     * @param namedParent the parent the caller named, or `null` to resolve one from where [component]
+     *   hangs in the Swing tree. Taken as a parameter rather than held as a field, so neither the
+     *   context nor the window it names outlives the call that uses them.
      */
-    fun start() {
+    fun start(namedParent: MountParent?) {
         check(component.islandCompositionContextOrNull() == null) {
             "${component.javaClass.name} already holds the content of a live setContent. A container is " +
                 "asked once for the composition its contents nest into, and two islands cannot both be " +
@@ -223,6 +261,13 @@ private class SetContentMountState(
         val arrivedIn = component.ownerWindowOrNull() ?: return
         val mountedIn = statedWindow.value
         when {
+            // Such a runtime serves a composition standing outside any window at all, so the window a
+            // container hangs in is something its content reads, never what decides which composition it
+            // belongs to. Only the window it reads is brought up to date.
+            standsOnItsOwnRuntime -> {
+                statedWindow.value = arrivedIn
+            }
+
             mountedIn == null -> {
                 statedWindow.value = arrivedIn
             }

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SetContentMount.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SetContentMount.kt
@@ -36,10 +36,10 @@ internal class MountParent(
  * `null` if it cannot be resolved yet (the container has no host stamp and no window ancestor, so the
  * mount must be deferred until [component] takes a place that answers).
  *
- * Resolution order: first an existing host discovered self-first up the Swing tree, then the owning
- * window's shared recomposer. Those two are the whole order: a runtime created for a component is
- * reached only by passing its context in, so every island a window can account for shares that window's
- * one recomposer and one frame clock.
+ * Resolution order: first an existing host discovered up the Swing tree - a stamped host composition, or
+ * an island standing over [component] - then the owning window's shared recomposer. Those two are the
+ * whole order: a runtime created for a component is reached only by passing its context in, so every
+ * island a window can account for shares that window's one recomposer and one frame clock.
  */
 internal fun resolveParentOrNull(component: Component): MountParent? {
     val window = component.ownerWindowOrNull()
@@ -59,7 +59,7 @@ internal fun resolveParentOrNull(component: Component): MountParent? {
  * Mounts a `setContent` on [component] as soon as the context it nests into can be resolved, and
  * returns a [DisposableHandle] over the (possibly still pending) mount.
  *
- * If the context resolves immediately (a host stamp self-first up the tree, or the owning window's
+ * If the context resolves immediately (a host stamp or an island up the tree, or the owning window's
  * recomposer), [mount] runs synchronously here. Otherwise the mount is **deferred** until [component]
  * takes a place in the Swing tree that resolves one, at which point [mount] runs.
  *
@@ -116,6 +116,9 @@ private enum class MountPhase { Pending, Mounted, Disposed }
  * renderer takes to be painted - has not moved at all. A mount that stood in no window at all adopts the
  * first one it reaches without composing again.
  *
+ * A live mount publishes the context its content composes under to whatever is mounted inside its
+ * container, through the [IslandMountRegistration] it keeps there.
+ *
  * Lives only on the EDT, so its fields need no synchronization. All phase transitions go through this
  * object, so no caller can drive it into an illegal state, and [dispose] leaves it [MountPhase.Disposed]
  * with no listener installed.
@@ -144,16 +147,34 @@ private class SetContentMountState(
      */
     private val statedWindow = mutableStateOf<Window?>(null)
 
-    /** Handle removing the listener watching [component]'s place; held until [dispose]. */
-    private var placeChanges: DisposableHandle? = null
+    /**
+     * This mount's registration on [component]: the listener watching where the container hangs, and the
+     * context it publishes to whatever is mounted inside that container. Installed by [start] and removed
+     * by [dispose].
+     */
+    private val registration = IslandMountRegistration { placeChanged() }
+
+    /**
+     * Set while a rejoin is queued, so the several parent changes one move fires queue at most one.
+     */
+    private var rejoinScheduled = false
 
     /**
      * Watches where [component] hangs and composes the content under the parent there is now: the one
      * the caller named, or the one [component]'s place resolves to. A container whose place resolves to
      * nothing composes nothing yet and waits for one that does.
+     *
+     * A container already carrying a live island is refused. Only a live one stands in the way: a
+     * container whose island was disposed takes content again, and one whose mount is still waiting for
+     * a parent answers nothing yet.
      */
     fun start() {
-        placeChanges = onPlaceChanged(component, PARENT_CHANGE_FLAG) { placeChanged() }
+        check(component.islandCompositionContextOrNull() == null) {
+            "${component.javaClass.name} already holds the content of a live setContent. A container is " +
+                "asked once for the composition its contents nest into, and two islands cannot both be " +
+                "that answer - dispose the first island's handle before setting content here again."
+        }
+        component.addHierarchyListener(registration)
         val parent = namedParent ?: resolveParentOrNull(component)
         if (parent != null) composeUnder(parent)
     }
@@ -177,6 +198,10 @@ private class SetContentMountState(
         // container already hanging in a window would otherwise fall back on nothing, with no later move
         // to adopt one on.
         statedWindow.value = component.ownerWindowOrNull() ?: parent.window
+        // Published before the mount for the same reason, and the same reason the applier stamps a node
+        // on its way down: the content composes inside mount(), so a setContent that pass makes on a
+        // container of this island has to find this context already standing.
+        registration.context = parent.context
         composition = mount(parent, statedWindow)
         phase = MountPhase.Mounted
     }
@@ -203,19 +228,50 @@ private class SetContentMountState(
             }
 
             mountedIn !== arrivedIn -> {
-                val resolved = resolveParentOrNull(component) ?: return
-                composition?.dispose()
-                statedWindow.value = arrivedIn
-                composition = mount(resolved, statedWindow)
+                // Withdrawn on the spot: AWT delivers a parent change to a container's descendants before
+                // the container itself, so an island nested inside this one is asked where it hangs while
+                // this mount still names the composition it is leaving. Answering nothing sends that walk
+                // on to where it really hangs now, and the rejoin publishes this island's new answer.
+                registration.context = null
+                scheduleRejoin()
             }
         }
+    }
+
+    /** Queues [rejoin] behind the event being dispatched, at most once at a time. */
+    private fun scheduleRejoin() {
+        if (rejoinScheduled) return
+        rejoinScheduled = true
+        SwingUtilities.invokeLater(::rejoin)
+    }
+
+    /** Composes the content again under what [component]'s place resolves to now. */
+    private fun rejoin() {
+        // Cleared first: a move made while this one runs must queue one of its own.
+        rejoinScheduled = false
+        parentToRejoin()?.let { parent ->
+            composition?.dispose()
+            composeUnder(parent)
+        }
+    }
+
+    /**
+     * The parent [component] is to compose again under, or `null` where there is nothing to compose
+     * again. Where the container stands is read here rather than carried over from when the rejoin was
+     * queued: it may since have been disposed, taken out of every window, or put back in the one it was
+     * already in.
+     */
+    private fun parentToRejoin(): MountParent? {
+        val arrivedIn = component.ownerWindowOrNull()
+        val moved = phase == MountPhase.Mounted && arrivedIn != null && arrivedIn !== statedWindow.value
+        return if (moved) resolveParentOrNull(component) else null
     }
 
     override fun dispose() {
         if (phase == MountPhase.Disposed) return
         phase = MountPhase.Disposed
-        placeChanges?.dispose()
-        placeChanges = null
+        component.removeHierarchyListener(registration)
+        registration.context = null
         composition?.dispose()
         composition = null
         statedWindow.value = null
@@ -223,10 +279,45 @@ private class SetContentMountState(
 }
 
 /**
+ * The registration a `setContent` mount keeps on its container: the [HierarchyListener] following where
+ * that container hangs, carrying the [CompositionContext] the mount's content composes under.
+ *
+ * A mount is asked what it composes under through the registration it already keeps, the way a window is
+ * asked for its runtime through the listener that ends it - so what a container's content nests into is
+ * answered by the container itself rather than tracked anywhere else, removing the listener is the whole
+ * of withdrawing the answer, and a container that is garbage collected takes its mounts with it. The
+ * registration also reaches a [java.awt.Container] that is no [javax.swing.JComponent], which carries no
+ * client-property bag at all.
+ *
+ * [context] is `null` while the mount is still waiting for a parent, and again once it is disposed.
+ *
+ * @param onPlaceChanged run whenever [HierarchyEvent.PARENT_CHANGED] fires for the container.
+ */
+private class IslandMountRegistration(
+    private val onPlaceChanged: () -> Unit,
+) : HierarchyListener {
+    var context: CompositionContext? = null
+
+    override fun hierarchyChanged(event: HierarchyEvent) {
+        if (event.changeFlags and PARENT_CHANGE_FLAG != 0L) onPlaceChanged()
+    }
+}
+
+/**
+ * The [CompositionContext] the content of a live `setContent` island on this component composes under,
+ * or `null` where this component carries no island that has composed yet.
+ */
+internal fun Component.islandCompositionContextOrNull(): CompositionContext? =
+    hierarchyListeners.firstNotNullOfOrNull { (it as? IslandMountRegistration)?.context }
+
+/**
  * Runs [block] on every [HierarchyEvent] fired for [component] whose change flags intersect
- * [changeFlags], for as long as the returned handle is live. Shared by every watch of where a
- * component stands in the Swing tree, so which flags answer that question is named once at each call
- * site rather than the listener plumbing repeated around a different answer.
+ * [changeFlags], for as long as the returned handle is live, so which flags answer where a component
+ * stands is named at the call site rather than written into a listener of its own.
+ *
+ * The listener it installs is anonymous, so this serves a watch that only needs the callback. A watch
+ * whose listener must be found again on the component - to be asked what it holds, rather than only to
+ * run - installs a named one instead.
  *
  * @return a [DisposableHandle] that removes the listener. Disposing is idempotent.
  */

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SwingFrameClock.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SwingFrameClock.kt
@@ -7,6 +7,7 @@ import java.awt.Component
 import java.awt.DisplayMode
 import javax.swing.SwingUtilities
 import javax.swing.Timer
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * The [MonotonicFrameClock] a [Recomposer] recomposes on, holding recomposition and frame-driven work
@@ -130,10 +131,16 @@ internal class SwingFrameClock(
 
     internal companion object {
         const val DEFAULT_FRAMES_PER_SECOND: Int = 60
-        private const val MILLIS_PER_SECOND: Int = 1000
 
-        private fun delayMillisFor(framesPerSecond: Int): Int =
-            (MILLIS_PER_SECOND / framesPerSecond.coerceAtLeast(1)).coerceAtLeast(1)
+        /**
+         * The [Timer] delay one frame of [framesPerSecond] takes, in whole milliseconds and never below
+         * one: a zero delay would fire the timer as fast as the event queue drains. A non-positive rate
+         * is read as a single frame per second.
+         */
+        private fun delayMillisFor(framesPerSecond: Int): Int {
+            val frame = 1.seconds / framesPerSecond.coerceAtLeast(1)
+            return frame.inWholeMilliseconds.coerceAtLeast(1).toInt()
+        }
 
         /**
          * The component's current display refresh rate in frames per second, read from

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SwingFrameClock.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SwingFrameClock.kt
@@ -2,47 +2,85 @@ package org.jetbrains.compose.swing.core
 
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.MonotonicFrameClock
+import androidx.compose.runtime.Recomposer
 import java.awt.Component
 import java.awt.DisplayMode
+import javax.swing.SwingUtilities
 import javax.swing.Timer
 
 /**
- * A [MonotonicFrameClock] backed by a Swing [Timer] that fires at a fixed nominal frame rate.
+ * The [MonotonicFrameClock] a [Recomposer] recomposes on, holding recomposition and frame-driven work
+ * to two separate cadences.
+ *
+ * Recomposition follows the event queue: the recomposer's frame is dispatched as an event of its own,
+ * so a declared state write reaches its widget a handful of event-dispatch cycles after the event that
+ * made it, rather than at the next tick of a frame cadence. It is one pass per event and not one per
+ * write: the frame is dispatched only once the Swing event that made the writes has returned, so a
+ * listener writing ten properties costs a single pass, and the pass that carries those writes is never
+ * inside the event that made them.
+ *
+ * Frame-driven work - [androidx.compose.runtime.withFrameNanos] and the animations built on it -
+ * advances at a nominal frame rate instead, paced by a [Timer] that runs only while something is
+ * awaiting a frame. Between one such frame and the next the recomposer's own clock is
+ * [paused][Recomposer.pauseCompositionFrameClock], which withholds the broadcast without withholding
+ * recomposition: a state write landing mid-animation applies on the cycles that follow the event that
+ * made it, without waiting for the animation's next frame, while every `withFrameNanos` caller stays
+ * exactly where it was, so the animation neither skips a frame nor jumps a step. The clock rests
+ * unpaused, so work that starts awaiting frames long after the last one wakes the recomposer the
+ * ordinary way.
  *
  * Frames are dispatched on the Event Dispatch Thread, so consumers of [withFrameNanos] receive frames
- * on the thread where recomposition and applier mutations run.
+ * on the thread where recomposition and applier mutations run. Every method here must be called on
+ * that thread.
  *
- * The timer runs only while there are awaiters: it starts on the first frame request and stops once
- * there are none, so an idle composition keeps no timer running. Call [dispose] when the owning
- * composition is torn down to guarantee the timer is stopped.
+ * A [Recomposer] takes the clock it recomposes on from the coroutine that runs
+ * [Recomposer.runRecomposeAndApplyChanges], not from the context it was constructed with. That is
+ * what lets this clock be built around the recomposer it paces and then handed to the coroutine that
+ * runs it.
  *
  * The cadence is a best-effort, nominal wall-clock rate, not vsync or variable-refresh-rate (VRR)
  * synchronization: actual frame delivery jitters with EDT load. [displayRefreshRate] reads a
  * component's display refresh rate to seed that cadence.
+ *
+ * Call [dispose] when the owning composition is torn down to guarantee the timer is stopped.
  */
 internal class SwingFrameClock(
+    private val recomposer: Recomposer,
     framesPerSecond: Int = DEFAULT_FRAMES_PER_SECOND,
 ) : MonotonicFrameClock {
     private val timer: Timer = Timer(delayMillisFor(framesPerSecond), null)
 
-    /** The timer's current cadence, in milliseconds. */
+    /** The timer's current cadence, in milliseconds: the interval frame-driven work advances on. */
     val frameDelayMillis: Int
         get() = timer.delay
 
-    private val broadcastClock =
-        BroadcastFrameClock(onNewAwaiters = {
-            // BroadcastFrameClock invokes this (under its lock) when the first awaiter appears.
-            if (!timer.isRunning) {
-                timer.start()
-            }
-        })
+    /**
+     * Whether the timer that paces frame-driven work is running. It runs only while something is
+     * awaiting a frame, so an idle composition keeps no timer of its own.
+     */
+    val isPacingFrameDrivenWork: Boolean
+        get() = timer.isRunning
+
+    /**
+     * The clock [recomposer] broadcasts frames on, which is where every `withFrameNanos` caller in its
+     * compositions parks. Its awaiter count is the true one - pausing hides those awaiters from the
+     * recomposer's own bookkeeping, never from the clock holding them.
+     */
+    private val compositionClock: BroadcastFrameClock =
+        checkNotNull(recomposer.effectCoroutineContext[MonotonicFrameClock] as? BroadcastFrameClock) {
+            "A Recomposer publishes its BroadcastFrameClock as the frame clock of its effect context"
+        }
+
+    private var dispatchScheduled = false
+
+    private val broadcastClock = BroadcastFrameClock(onNewAwaiters = ::scheduleDispatch)
 
     init {
         timer.addActionListener {
-            broadcastClock.sendFrame(System.nanoTime())
-            if (!broadcastClock.hasAwaiters) {
-                timer.stop()
-            }
+            // Resuming requests a frame of its own when frame-driven work is pending, which is what
+            // carries that work forward by exactly one step: the dispatch that serves it pauses again.
+            recomposer.resumeCompositionFrameClock()
+            if (!compositionClock.hasAwaiters) timer.stop()
         }
     }
 
@@ -64,6 +102,30 @@ internal class SwingFrameClock(
      */
     fun dispose() {
         timer.stop()
+    }
+
+    /**
+     * Queues the frame the recomposer just asked for behind the event being dispatched, so every write
+     * that event still has to make joins it. [BroadcastFrameClock] calls this (under its lock) when the
+     * first awaiter appears, which for this clock is the recomposer and nothing else.
+     */
+    private fun scheduleDispatch() {
+        if (dispatchScheduled) return
+        dispatchScheduled = true
+        SwingUtilities.invokeLater(::dispatchFrame)
+    }
+
+    private fun dispatchFrame() {
+        // Cleared first: a frame the recomposer asks for again while this one runs must re-arm.
+        dispatchScheduled = false
+        // Read before the frame, because an awaiter this frame resumes re-registers from a later
+        // dispatch cycle - after which the pause below is already in force.
+        val carriesFrameDrivenWork = compositionClock.hasAwaiters
+        broadcastClock.sendFrame(System.nanoTime())
+        if (carriesFrameDrivenWork) {
+            recomposer.pauseCompositionFrameClock()
+            if (!timer.isRunning) timer.start()
+        }
     }
 
     internal companion object {

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SwingRecomposer.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/SwingRecomposer.kt
@@ -14,13 +14,13 @@ import java.awt.Component
 import java.beans.PropertyChangeListener
 
 /**
- * The runtime a composition is driven by: a single [Recomposer], the frame clock that paces it, and the
+ * The runtime a composition is driven by: a single [Recomposer], the frame clock it recomposes on, and the
  * [CoroutineScope] they run on. Every island nested into one of these recomposes on one recomposer and
  * one frame clock.
  *
- * The clock is cadenced to the display the component the runtime was created for is on, and follows
- * that component across displays: a component reports every [java.awt.GraphicsConfiguration] change,
- * including the ones an ancestor propagates down to it.
+ * Frame-driven work is cadenced to the display the component the runtime was created for is on, and
+ * follows that component across displays: a component reports every [java.awt.GraphicsConfiguration]
+ * change, including the ones an ancestor propagates down to it.
  *
  * Content is mounted on the runtime by passing its [compositionContext] as the parent of a mount.
  *
@@ -64,14 +64,14 @@ public class SwingRecomposer private constructor(
         private const val GRAPHICS_CONFIGURATION_PROPERTY: String = "graphicsConfiguration"
 
         /**
-         * Starts a runtime paced by the display [component] is on, running at a default cadence while
-         * that component is outside any container. This is what serves content built to be read rather
-         * than shown, which reaches a composition with no window anywhere in the picture.
+         * Starts a runtime whose frame-driven work is paced by the display [component] is on, running
+         * at a default cadence while that component is outside any container. This is what serves
+         * content built to be read rather than shown, which reaches a composition with no window
+         * anywhere in the picture.
          *
-         * The runtime is reachable only through the [compositionContext] the returned instance carries:
-         * it is left off the component's composition stamp, so a mount that resolves its parent from the
-         * Swing tree resolves a host composition or the window's one runtime, and two islands under one
-         * window stay on one recomposer and one frame clock.
+         * Creating the runtime publishes nothing on [component], so a mount resolving its parent from
+         * the Swing tree reaches this runtime only through content a caller has already mounted under
+         * it, and two islands a window accounts for stay on one recomposer and one frame clock.
          *
          * The caller owns the returned runtime and decides when it ends: [dispose] it once the content
          * it drives is torn down. Content that belongs to a window joins that window's own runtime
@@ -82,10 +82,10 @@ public class SwingRecomposer private constructor(
         public fun create(component: Component): SwingRecomposer {
             checkEventDispatchThread()
             GlobalSnapshotManager.ensureStarted()
-            val clock = SwingFrameClock(component.displayRefreshRate())
-            val scope = CoroutineScope(Dispatchers.Swing + Job() + clock)
+            val scope = CoroutineScope(Dispatchers.Swing + Job())
             val recomposer = Recomposer(scope.coroutineContext)
-            scope.launch {
+            val clock = SwingFrameClock(recomposer, component.displayRefreshRate())
+            scope.launch(clock) {
                 recomposer.runRecomposeAndApplyChanges()
             }
             // Retime the clock when the component moves to a display with a different refresh rate. Fires

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/WindowRecomposer.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/core/WindowRecomposer.kt
@@ -13,8 +13,8 @@ import javax.swing.RootPaneContainer
  * same one on every call after it.
  *
  * Content mounted under it recomposes together with the rest of this window's content, on one
- * recomposition scope paced by the display the window is on. The window owns the context and tears it
- * down when it is disposed.
+ * recomposition scope whose frame-driven work is paced by the display the window is on. The window owns
+ * the context and tears it down when it is disposed.
  *
  * Pass it as the parent context of a mount to join this window's composition - which is what a mount
  * on a container already under this window resolves to on its own.

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/modifier/appearance/TextHighlights.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/modifier/appearance/TextHighlights.kt
@@ -39,7 +39,10 @@ import javax.swing.text.JTextComponent
 public fun SwingModifier.highlights(
     ranges: List<TextRange>,
     painter: Highlighter.HighlightPainter,
-): SwingModifier = this then HighlightsElement(ranges, painter)
+): SwingModifier =
+    // Reading the ranges here is what makes the composition declaring this chain one of their readers, so
+    // a caller that keeps them in a snapshot list and mutates it in place invalidates that composition.
+    this then HighlightsElement(ranges.toList(), painter)
 
 /**
  * Re-paints a text component's highlighter with the declared ranges whenever the declaration changes,
@@ -50,6 +53,9 @@ public fun SwingModifier.highlights(
  *
  * The [painter] is the caller's own object, handed to the highlighter as the mark's painter, so it is
  * compared by identity - the same comparison the node makes against what it has already painted.
+ *
+ * [ranges] is a list no caller holds. An equal element leaves the chain it declares adopted as-is, so
+ * what a later declaration is compared against must be a list nothing outside can change under it.
  */
 private class HighlightsElement(
     private val ranges: List<TextRange>,
@@ -88,8 +94,7 @@ private class HighlightsElement(
 
         /**
          * Paints [ranges] with [painter], unless what is already painted came from an equal declaration
-         * against the same document and [force] is not set. The ranges are snapshotted, so what is
-         * recorded as painted cannot be the very list a later declaration is compared against.
+         * against the same document and [force] is not set.
          */
         fun apply(force: Boolean) {
             val declaredRanges = ranges
@@ -99,7 +104,7 @@ private class HighlightsElement(
             val highlighter = component.highlighter
             if (declaredPainter == null || highlighter == null) return
             if (!force && declaredPainter === appliedPainter && declaredRanges == appliedRanges) return
-            appliedRanges = declaredRanges.toList()
+            appliedRanges = declaredRanges
             appliedPainter = declaredPainter
 
             removePainted(highlighter)

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/node/AppliedValue.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/node/AppliedValue.kt
@@ -27,6 +27,11 @@ import java.awt.Component
  * not. The next pass acts on that answer: an adopted move leaves the widget alone, an unadopted one
  * writes the declaration back, so the widget snaps away from where the user put it.
  *
+ * The pass is a later event than the move, and Swing has already queued the repaint the move provoked,
+ * so the widget can be painted once holding a value the caller rejected. The pass follows within a few
+ * event-dispatch cycles, inside a single display refresh interval. That bounds how long the rejected
+ * value survives; it is not a guarantee that the value is never shown.
+ *
  * Runs on the event dispatch thread.
  */
 public class AppliedValue<V>

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/Application.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/Application.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.swing.Swing
@@ -153,18 +154,18 @@ public fun CoroutineScope.launchApplication(content: @Composable ApplicationScop
  * flow into their content.
  */
 public suspend fun awaitApplication(content: @Composable ApplicationScope.() -> Unit) {
-    val frameClock = SwingFrameClock()
-    try {
-        withContext(Dispatchers.Swing) {
-            withContext(frameClock) {
-                GlobalSnapshotManager.ensureStarted()
+    withContext(Dispatchers.Swing) {
+        GlobalSnapshotManager.ensureStarted()
 
-                val recomposer = Recomposer(coroutineContext)
-                var isOpen by mutableStateOf(true)
+        val recomposer = Recomposer(coroutineContext)
+        val frameClock = SwingFrameClock(recomposer)
+        try {
+            var isOpen by mutableStateOf(true)
 
-                val applicationScope = ApplicationScopeImpl { isOpen = false }
+            val applicationScope = ApplicationScopeImpl { isOpen = false }
 
-                launch {
+            coroutineScope {
+                launch(frameClock) {
                     recomposer.runRecomposeAndApplyChanges()
                 }
 
@@ -184,9 +185,9 @@ public suspend fun awaitApplication(content: @Composable ApplicationScope.() -> 
                     }
                 }
             }
+        } finally {
+            frameClock.dispose()
         }
-    } finally {
-        frameClock.dispose()
     }
 }
 

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/UnadoptedMovePutBack.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/UnadoptedMovePutBack.kt
@@ -1,0 +1,138 @@
+package org.jetbrains.compose.swing
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.yield
+import org.jetbrains.compose.swing.core.SwingRecomposer
+import java.awt.Component
+import javax.swing.JPanel
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Mounts [content], moves the single widget it declares off [declared] as the user would, and asserts
+ * the declaration is back on the widget within [PUT_BACK_CYCLES] event-dispatch cycles. The caller
+ * adopts nothing, so every move made here is one the composition puts back.
+ *
+ * This runs on a real [SwingRecomposer]. The test harness paces its own composition on a clock the test
+ * drives by hand, which takes the cadence under test out of the picture.
+ *
+ * The timer that paces frame-driven work is asserted to stay stopped throughout, so the put-back is
+ * pinned to the event queue rather than to how long the assertion waits.
+ *
+ * [move] is asserted to land on the widget before the put-back is counted, so a gesture the widget
+ * ignores fails here rather than passing for having nothing to undo.
+ *
+ * @param type the class the widget under test is built as
+ * @param declared the value [content] declares, which the widget must be holding again at the end
+ * @param content the content under test, declaring exactly one component
+ * @param move the user's move, made on the widget itself
+ * @param read the widget property [declared] is measured against
+ */
+internal suspend fun <C : Component> assertUnadoptedMoveIsPutBack(
+    type: Class<C>,
+    declared: Any?,
+    content: @Composable () -> Unit,
+    move: (C) -> Unit,
+    read: (C) -> Any?,
+) {
+    val island = JPanel()
+    val runtime = SwingRecomposer.create(island)
+    var mounted: DisposableHandle? = null
+    try {
+        // setContent composes and applies before it returns, so the widget is on the island already and
+        // there is nothing to wait for here.
+        mounted = island.setContent(parent = runtime.compositionContext, content = content)
+        val child =
+            island.components.singleOrNull()
+                ?: fail("The content must declare exactly one component, and declared ${island.componentCount}")
+        assertTrue(
+            type.isInstance(child),
+            "The content must declare a ${type.simpleName}, and declared a ${child.javaClass.simpleName}",
+        )
+        val widget = type.cast(child)
+        assertEquals(declared, read(widget), "the widget must mount holding what the content declares")
+
+        move(widget)
+        assertNotEquals(
+            declared,
+            read(widget),
+            "the move must land on the ${type.simpleName} before the put-back is counted",
+        )
+
+        awaitWithin(PUT_BACK_CYCLES) {
+            // Asserted on every cycle rather than once at the end: the timer stops itself as soon as
+            // nothing awaits a frame, so a tick that came and went would leave nothing to find here.
+            assertNothingIsPaced(runtime)
+            read(widget) == declared
+        }
+            ?: fail(
+                "A move the caller does not adopt must come off the ${type.simpleName} on the cycles right " +
+                    "after the event that made it, not a frame interval later; it still held " +
+                    "${read(widget)} after $PUT_BACK_CYCLES event-dispatch cycles",
+            )
+    } finally {
+        mounted?.dispose()
+        runtime.dispose()
+    }
+}
+
+/**
+ * Fails if [runtime] has started the timer that paces frame-driven work.
+ *
+ * A put-back travels the event queue, and the content under test awaits no frame, so that timer must
+ * never run.
+ */
+private fun assertNothingIsPaced(runtime: SwingRecomposer) {
+    assertFalse(
+        runtime.clock.isPacingFrameDrivenWork,
+        "a put-back must reach the widget on the event queue, and nothing here awaits a frame, so the " +
+            "timer that paces frame-driven work must never start",
+    )
+}
+
+/**
+ * Yields the event dispatch thread up to [cycles] times - checking [condition] before each yield and
+ * once more after the last one - and answers how many cycles it took to hold, or `null` if it never
+ * did. The cycle count is the only bound: with no deadline behind it, a composition that never settles
+ * fails on the count rather than on a wall-clock limit that varies with the machine.
+ *
+ * [condition] may assert. A failure it raises is passed on rather than read as a cycle where the
+ * condition did not hold.
+ */
+private suspend fun awaitWithin(
+    cycles: Int,
+    condition: () -> Boolean,
+): Int? {
+    val schedule = 0..cycles
+    for (cycle in schedule) {
+        if (condition()) return cycle
+        // Not after the last check: a yield nothing looks at again spends a cycle to learn nothing, and
+        // puts the count past what this bound states.
+        if (cycle < schedule.last) yield()
+    }
+    return null
+}
+
+/**
+ * The event-dispatch cycles a move the caller does not adopt may take to come off the widget.
+ *
+ * The count is a property of the path the answer travels, which is the same for every widget:
+ *
+ * ```
+ * cycle 0   the move          the widget reports it, and the mirror records it as snapshot state;
+ *                             that write schedules an apply notification
+ * cycle 1   the notification  the write is published to the composition, which invalidates the
+ *                             component that reads the mirror and asks the clock for a frame
+ * cycle 2   the frame         the pass recomposes and settles the declaration back onto the widget
+ * ```
+ *
+ * Every widget measures two cycles. The cap is one above that, as room for a dispatch hop rather than a
+ * tolerance to grow: a put-back that needs more cycles no longer follows the event queue, which is what
+ * these tests exist to pin, so raising this constant would retire them rather than fix them. Paced by a
+ * frame clock instead, the same tests reach the declaration after tens of thousands of cycles.
+ */
+private const val PUT_BACK_CYCLES: Int = 3

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/ComboBoxSelectionFeedbackTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/ComboBoxSelectionFeedbackTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import java.awt.event.ActionEvent
@@ -349,6 +351,23 @@ class ComboBoxSelectionFeedbackTest {
             listOf("comboBoxChanged", "comboBoxChanged", "comboBoxEdited", "comboBoxChanged"),
             commands,
             "the user's commit and the wrapper's reassertion of the declared item both reach the raw listener",
+        )
+    }
+
+    @Test
+    fun aChoiceTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JComboBox::class.java,
+            declared = "Ada",
+            content = {
+                ComboBox(
+                    items = listOf("Ada", "Alan", "Grace"),
+                    selectedItem = "Ada",
+                    onSelectionChange = {},
+                )
+            },
+            move = { it.selectedIndex = 2 },
+            read = { it.selectedItem },
         )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/ComboBoxStateListItemsTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/ComboBoxStateListItemsTest.kt
@@ -1,0 +1,107 @@
+package org.jetbrains.compose.swing.components
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.test.onNodeOfType
+import org.jetbrains.compose.swing.test.runComposeSwingTest
+import java.awt.event.ActionListener
+import java.beans.PropertyChangeListener
+import javax.swing.JComboBox
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [ComboBox] declared over a list the caller keeps and mutates, rather than one rebuilt each pass.
+ *
+ * Declared items reach the combo box as a model built around a copy of them, so a pass that adopts new
+ * items swaps the model the combo box holds. These tests assert on that swap, because it is what a
+ * `JComboBox` acts on: a model that was never swapped is still offering the old items however the
+ * caller's own list reads back.
+ */
+class ComboBoxStateListItemsTest {
+    @Test
+    fun addingToADeclaredStateListReachesTheComboBox() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada")
+        setContent { ComboBox(items = items, selectedItem = "Ada", onSelectionChange = {}) }
+
+        val comboBox = onNodeOfType<JComboBox<*>>().fetch()
+        val swaps = comboBox.recordModelSwaps()
+
+        items.add("Alan")
+        awaitIdle()
+
+        assertTrue(swaps.isNotEmpty(), "the combo box was never given a model holding the new item")
+        assertEquals(listOf("Ada", "Alan"), comboBox.elements(), "the combo box should offer both items")
+    }
+
+    @Test
+    fun removingFromADeclaredStateListReachesTheComboBox() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada", "Alan")
+        setContent { ComboBox(items = items, selectedItem = "Ada", onSelectionChange = {}) }
+
+        val comboBox = onNodeOfType<JComboBox<*>>().fetch()
+        val swaps = comboBox.recordModelSwaps()
+
+        items.removeAt(1)
+        awaitIdle()
+
+        assertTrue(swaps.isNotEmpty(), "the combo box was never given a model holding the remaining item")
+        assertEquals(listOf("Ada"), comboBox.elements(), "the combo box should offer the remaining item")
+    }
+
+    @Test
+    fun addingToADeclaredStateListReachesARawListenerComboBox() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada")
+        setContent {
+            ComboBox(items = items, selectedItem = "Ada", actionListener = ActionListener { })
+        }
+
+        val comboBox = onNodeOfType<JComboBox<*>>().fetch()
+        val swaps = comboBox.recordModelSwaps()
+
+        items.add("Alan")
+        awaitIdle()
+
+        assertTrue(swaps.isNotEmpty(), "the combo box was never given a model holding the new item")
+        assertEquals(listOf("Ada", "Alan"), comboBox.elements(), "the combo box should offer both items")
+    }
+
+    @Test
+    fun aPassThatChangesNoItemSwapsNoModel() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada")
+        var maximumRowCount by mutableStateOf(4)
+        setContent {
+            ComboBox(
+                items = items,
+                selectedItem = "Ada",
+                onSelectionChange = {},
+                maximumRowCount = maximumRowCount,
+            )
+        }
+
+        val comboBox = onNodeOfType<JComboBox<*>>().fetch()
+        val swaps = comboBox.recordModelSwaps()
+
+        maximumRowCount = 6
+        awaitIdle()
+
+        assertEquals(6, comboBox.maximumRowCount, "the pass should have applied the new row count")
+        assertTrue(
+            swaps.isEmpty(),
+            "a pass that changed no item should leave the combo box on the model it holds",
+        )
+    }
+}
+
+/** Records every model the combo box is given from now on, newest last. */
+private fun JComboBox<*>.recordModelSwaps(): List<Any?> {
+    val swaps = mutableListOf<Any?>()
+    addPropertyChangeListener("model", PropertyChangeListener { swaps += it.newValue })
+    return swaps
+}
+
+/** The items the combo box is currently offering, in order. */
+private fun JComboBox<*>.elements(): List<Any?> = (0 until model.size).map { model.getElementAt(it) }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/SpinnerStateListItemsTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/SpinnerStateListItemsTest.kt
@@ -1,0 +1,111 @@
+package org.jetbrains.compose.swing.components
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.modifier.SwingModifier
+import org.jetbrains.compose.swing.modifier.appearance.toolTip
+import org.jetbrains.compose.swing.test.onNodeOfType
+import org.jetbrains.compose.swing.test.runComposeSwingTest
+import javax.swing.JSpinner
+import javax.swing.event.ChangeEvent
+import javax.swing.event.ChangeListener
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [Spinner] declared over a list the caller keeps and mutates, rather than one rebuilt each pass.
+ *
+ * A `JSpinner` repaints what its model tells it changed. A model answering the caller's own list hands
+ * the new items to anything that asks, so a value read back off the model is no evidence the spinner was
+ * told: these tests assert on the change events the model fires.
+ */
+class SpinnerStateListItemsTest {
+    @Test
+    fun addingToADeclaredStateListNotifiesTheSpinner() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada")
+        setContent { Spinner(items = items, value = "Ada", onValueChange = {}) }
+
+        val spinner = onNodeOfType<JSpinner>().fetch()
+        val changes = spinner.recordChanges()
+
+        items.add("Alan")
+        awaitIdle()
+
+        assertTrue(changes.isNotEmpty(), "the spinner was never told its items changed")
+        assertEquals("Alan", spinner.model.nextValue, "the spinner should step onto the new item")
+    }
+
+    @Test
+    fun removingFromADeclaredStateListNotifiesTheSpinner() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada", "Alan")
+        setContent { Spinner(items = items, value = "Ada", onValueChange = {}) }
+
+        val spinner = onNodeOfType<JSpinner>().fetch()
+        val changes = spinner.recordChanges()
+
+        items.removeAt(1)
+        awaitIdle()
+
+        assertTrue(changes.isNotEmpty(), "the spinner was never told its items changed")
+        assertEquals(null, spinner.model.nextValue, "the spinner should have nothing left to step onto")
+    }
+
+    @Test
+    fun theModelAnswersOutOfItsOwnItemsUntilAPassCarriesTheChange() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada", "Alan")
+        setContent { Spinner(items = items, value = "Ada", onValueChange = {}) }
+        awaitIdle()
+        mainClock.autoAdvance = false
+
+        val spinner = onNodeOfType<JSpinner>().fetch()
+        assertEquals("Alan", spinner.model.nextValue, "the spinner should start out able to step onto Alan")
+
+        // The caller drops the item the spinner can step onto, and no pass has carried that yet. A model
+        // reading the caller's list would answer out of it here - including during a paint, which Swing
+        // schedules whenever it likes rather than when a pass says so.
+        items.removeAt(1)
+        awaitIdle()
+
+        assertEquals(
+            "Alan",
+            spinner.model.nextValue,
+            "the model must answer out of the items the spinner was last told about, not the caller's list",
+        )
+
+        mainClock.advanceTimeByFrame()
+
+        assertEquals(
+            null,
+            spinner.model.nextValue,
+            "the pass carrying the change should leave the model with nothing to step onto",
+        )
+    }
+
+    @Test
+    fun aPassThatChangesNoItemNotifiesNothing() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada", "Alan")
+        var tip by mutableStateOf("Pick a name")
+        setContent {
+            Spinner(items = items, value = "Ada", onValueChange = {}, modifier = SwingModifier.toolTip(tip))
+        }
+
+        val spinner = onNodeOfType<JSpinner>().fetch()
+        val changes = spinner.recordChanges()
+
+        tip = "Who is who"
+        awaitIdle()
+
+        assertEquals("Who is who", spinner.toolTipText, "the pass this asserts about has to have run")
+        assertTrue(changes.isEmpty(), "a pass that changed no item should leave the spinner alone")
+    }
+}
+
+/** Records every change the spinner reports from now on, newest last. */
+private fun JSpinner.recordChanges(): List<ChangeEvent> {
+    val changes = mutableListOf<ChangeEvent>()
+    addChangeListener(ChangeListener { changes += it })
+    return changes
+}

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/ValueComponentsTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/ValueComponentsTest.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.components.text.TextArea
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import javax.swing.DefaultBoundedRangeModel
@@ -12,6 +14,7 @@ import javax.swing.JLabel
 import javax.swing.JProgressBar
 import javax.swing.JSeparator
 import javax.swing.JSlider
+import javax.swing.JSpinner
 import javax.swing.JTextArea
 import javax.swing.SwingConstants
 import kotlin.test.Test
@@ -354,5 +357,27 @@ class ValueComponentsTest {
         caption = "after"
         awaitIdle()
         onNodeOfType<JLabel>().assertTextEquals("after")
+    }
+
+    @Test
+    fun aSliderMoveTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JSlider::class.java,
+            declared = 10,
+            content = { Slider(value = 10, onValueChange = {}) },
+            move = { it.value = 80 },
+            read = { it.value },
+        )
+    }
+
+    @Test
+    fun aSpinnerMoveTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JSpinner::class.java,
+            declared = 1,
+            content = { Spinner(value = 1, onValueChange = {}) },
+            move = { it.value = 5 },
+            read = { it.value },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/button/CheckBoxBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/button/CheckBoxBehaviorTest.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.modifier.SwingModifier
 import org.jetbrains.compose.swing.modifier.appearance.toolTip
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.SwingMatcher
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
@@ -246,5 +248,16 @@ class CheckBoxBehaviorTest {
         text = "Wrap lines"
         awaitIdle()
         checkBox.assert(SwingMatcher.isSelected(false))
+    }
+
+    @Test
+    fun aClickTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JCheckBox::class.java,
+            declared = false,
+            content = { CheckBox(text = "Word wrap", checked = false, onCheckedChange = {}) },
+            move = { it.doClick(0) },
+            read = { it.isSelected },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/button/RadioButtonBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/button/RadioButtonBehaviorTest.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.modifier.SwingModifier
 import org.jetbrains.compose.swing.modifier.appearance.toolTip
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.SwingMatcher
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
@@ -256,5 +258,16 @@ class RadioButtonBehaviorTest {
         text = "Comfortable"
         awaitIdle()
         radioButton.assert(SwingMatcher.isSelected())
+    }
+
+    @Test
+    fun aSelectionTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JRadioButton::class.java,
+            declared = false,
+            content = { RadioButton(text = "Nightly", selected = false, onSelectedChange = {}) },
+            move = { it.doClick(0) },
+            read = { it.isSelected },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/button/ToggleButtonBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/button/ToggleButtonBehaviorTest.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.modifier.SwingModifier
 import org.jetbrains.compose.swing.modifier.appearance.toolTip
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.SwingMatcher
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
@@ -270,5 +272,16 @@ class ToggleButtonBehaviorTest {
         text = "Strong"
         awaitIdle()
         toggle.assert(SwingMatcher.isSelected())
+    }
+
+    @Test
+    fun aSelectingClickTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JToggleButton::class.java,
+            declared = false,
+            content = { ToggleButton(text = "Bold", selected = false, onSelectedChange = {}) },
+            move = { it.doClick(0) },
+            read = { it.isSelected },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/layout/TabbedPaneSelectionReportingTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/layout/TabbedPaneSelectionReportingTest.kt
@@ -6,12 +6,14 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.components.Label
 import org.jetbrains.compose.swing.modifier.SwingModifier
 import org.jetbrains.compose.swing.modifier.applyModifier
 import org.jetbrains.compose.swing.modifier.layout.preferredSize
 import org.jetbrains.compose.swing.modifier.listener.changeListener
 import org.jetbrains.compose.swing.node.SwingNode
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.ComposeSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
@@ -611,5 +613,21 @@ class TabbedPaneSelectionReportingTest {
 
         selectTab(0)
         assertEquals(listOf(0), reported, "the selection the user makes should reach the declared listener")
+    }
+
+    @Test
+    fun aSelectionTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JTabbedPane::class.java,
+            declared = 0,
+            content = {
+                TabbedPane(selectedIndex = 0, onSelectedIndexChange = {}) {
+                    Label("g", SwingModifier.tab("General"))
+                    Label("a", SwingModifier.tab("Advanced"))
+                }
+            },
+            move = { it.selectedIndex = 1 },
+            read = { it.selectedIndex },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/ListBoxBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/ListBoxBehaviorTest.kt
@@ -3,6 +3,8 @@ package org.jetbrains.compose.swing.components.selection
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import javax.swing.JList
@@ -143,5 +145,22 @@ class ListBoxBehaviorTest {
         awaitIdle()
 
         assertEquals(listOf(2 to 0), positions, "the anchor and lead of the range should reach the listener")
+    }
+
+    @Test
+    fun aSelectionTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JList::class.java,
+            declared = emptyList<Int>(),
+            content = {
+                ListBox(
+                    items = listOf("Ada", "Alan", "Grace"),
+                    selectedIndices = emptySet(),
+                    onSelectionChange = {},
+                )
+            },
+            move = { it.selectedIndex = 1 },
+            read = { it.selectedIndices.toList() },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/ListBoxStateListItemsTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/ListBoxStateListItemsTest.kt
@@ -1,0 +1,79 @@
+package org.jetbrains.compose.swing.components.selection
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.test.onNodeOfType
+import org.jetbrains.compose.swing.test.runComposeSwingTest
+import java.beans.PropertyChangeListener
+import javax.swing.JList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [ListBox] declared over a list the caller keeps and mutates, rather than one rebuilt each pass.
+ *
+ * Declared items reach the list as a model built around a copy of them, so a pass that adopts new items
+ * swaps the model the list holds. These tests assert on that swap, because it is what a `JList` acts on:
+ * the model it was holding is left behind entirely, and a model that was never swapped is still showing
+ * the old items however the caller's own list reads back.
+ */
+class ListBoxStateListItemsTest {
+    @Test
+    fun addingToADeclaredStateListReachesTheList() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada")
+        setContent { ListBox(items = items) }
+
+        val list = onNodeOfType<JList<*>>().fetch()
+        val swaps = list.recordModelSwaps()
+
+        items.add("Alan")
+        awaitIdle()
+
+        assertTrue(swaps.isNotEmpty(), "the list was never given a model holding the new item")
+        assertEquals(listOf("Ada", "Alan"), list.elements(), "the list should show both items")
+    }
+
+    @Test
+    fun removingFromADeclaredStateListReachesTheList() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada", "Alan")
+        setContent { ListBox(items = items) }
+
+        val list = onNodeOfType<JList<*>>().fetch()
+        val swaps = list.recordModelSwaps()
+
+        items.removeAt(0)
+        awaitIdle()
+
+        assertTrue(swaps.isNotEmpty(), "the list was never given a model holding the remaining item")
+        assertEquals(listOf("Alan"), list.elements(), "the list should show the remaining item")
+    }
+
+    @Test
+    fun aPassThatChangesNoItemSwapsNoModel() = runComposeSwingTest {
+        val items = mutableStateListOf("Ada")
+        var visibleRowCount by mutableStateOf(4)
+        setContent { ListBox(items = items, visibleRowCount = visibleRowCount) }
+
+        val list = onNodeOfType<JList<*>>().fetch()
+        val swaps = list.recordModelSwaps()
+
+        visibleRowCount = 6
+        awaitIdle()
+
+        assertEquals(6, list.visibleRowCount, "the pass should have applied the new row count")
+        assertTrue(swaps.isEmpty(), "a pass that changed no item should leave the list on the model it holds")
+    }
+}
+
+/** Records every model the list is given from now on, newest last. */
+private fun JList<*>.recordModelSwaps(): List<Any?> {
+    val swaps = mutableListOf<Any?>()
+    addPropertyChangeListener("model", PropertyChangeListener { swaps += it.newValue })
+    return swaps
+}
+
+/** The items the list is currently showing, in order. */
+private fun JList<*>.elements(): List<Any?> = (0 until model.size).map { model.getElementAt(it) }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TableBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TableBehaviorTest.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.modifier.SwingModifier
 import org.jetbrains.compose.swing.modifier.appearance.name
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import javax.swing.JCheckBox
@@ -259,5 +261,24 @@ class TableBehaviorTest {
 
         assertSame(column, table.columnModel.getColumn(0), "the column survives a pass that changed no data")
         assertEquals(123, table.columnModel.getColumn(0).preferredWidth, "and so does the width set on it")
+    }
+
+    @Test
+    fun aSelectionTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JTable::class.java,
+            declared = emptyList<Int>(),
+            content = {
+                Table(
+                    rows = listOf("Ada", "Alan"),
+                    selectedRowIndices = emptySet(),
+                    onSelectionChange = {},
+                ) {
+                    column("Name") { it }
+                }
+            },
+            move = { it.setRowSelectionInterval(1, 1) },
+            read = { it.selectedRows.toList() },
+        )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TableStateListRowsTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TableStateListRowsTest.kt
@@ -1,0 +1,145 @@
+package org.jetbrains.compose.swing.components.selection
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.test.onNodeOfType
+import org.jetbrains.compose.swing.test.runComposeSwingTest
+import javax.swing.JTable
+import javax.swing.event.TableModelEvent
+import javax.swing.event.TableModelListener
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [Table] declared over a list the caller keeps and mutates, rather than one rebuilt each pass.
+ *
+ * A `JTable` repaints what a `TableModel` tells it changed. A model that answers a caller's list
+ * directly reports the new contents to anything that asks, so a row count read back is no evidence
+ * the table was told: these tests assert on the events the model fires.
+ */
+class TableStateListRowsTest {
+    @Test
+    fun addingToADeclaredStateListNotifiesTheTable() = runComposeSwingTest {
+        val rows = mutableStateListOf(Person("Ada", 36))
+        setContent {
+            Table(rows = rows) {
+                column("Name") { it.name }
+            }
+        }
+
+        val table = onNodeOfType<JTable>().fetch()
+        val events = mutableListOf<TableModelEvent>()
+        table.model.addTableModelListener(TableModelListener { events += it })
+
+        rows.add(Person("Alan", 41))
+        awaitIdle()
+
+        assertEquals(2, table.model.rowCount, "the model should hold both rows")
+        assertTrue(
+            events.isNotEmpty(),
+            "the table was never told its rows changed, so it will not repaint them",
+        )
+    }
+
+    @Test
+    fun removingFromADeclaredStateListNotifiesTheTable() = runComposeSwingTest {
+        val rows = mutableStateListOf(Person("Ada", 36), Person("Alan", 41))
+        setContent {
+            Table(rows = rows) {
+                column("Name") { it.name }
+            }
+        }
+
+        val table = onNodeOfType<JTable>().fetch()
+        val events = mutableListOf<TableModelEvent>()
+        table.model.addTableModelListener(TableModelListener { events += it })
+
+        rows.removeAt(0)
+        awaitIdle()
+
+        assertEquals(1, table.model.rowCount, "the model should hold the remaining row")
+        assertTrue(
+            events.isNotEmpty(),
+            "the table was never told its rows changed, so it will not repaint them",
+        )
+    }
+
+    @Test
+    fun replacingARowInADeclaredStateListNotifiesTheTable() = runComposeSwingTest {
+        val rows = mutableStateListOf(Person("Ada", 36))
+        setContent {
+            Table(rows = rows) {
+                column("Name") { it.name }
+            }
+        }
+
+        val table = onNodeOfType<JTable>().fetch()
+        val events = mutableListOf<TableModelEvent>()
+        table.model.addTableModelListener(TableModelListener { events += it })
+
+        rows[0] = Person("Alan", 41)
+        awaitIdle()
+
+        assertEquals("Alan", table.model.getValueAt(0, 0), "the model should hold the replacing row")
+        assertTrue(
+            events.isNotEmpty(),
+            "the table was never told its rows changed, so it will not repaint them",
+        )
+    }
+
+    @Test
+    fun theModelAnswersOutOfTheRowsItReportedUntilAPassCarriesTheChange() = runComposeSwingTest {
+        val rows = mutableStateListOf(Person("Ada", 36), Person("Alan", 41))
+        setContent {
+            Table(rows = rows) {
+                column("Name") { it.name }
+            }
+        }
+        awaitIdle()
+        mainClock.autoAdvance = false
+
+        val table = onNodeOfType<JTable>().fetch()
+        assertEquals(2, table.model.rowCount, "the table should start out showing both rows")
+
+        // The caller drops a row, and no pass has carried that yet. A model reading the caller's list
+        // would report one row here while the table still paints two, so a repaint arriving before the
+        // pass reads past the end of what it was told.
+        rows.removeAt(1)
+        awaitIdle()
+
+        assertEquals(
+            2,
+            table.model.rowCount,
+            "the model must report the rows the table was last told about, not the caller's list",
+        )
+        assertEquals("Alan", table.model.getValueAt(1, 0), "the dropped row must still be readable")
+
+        mainClock.advanceTimeByFrame()
+
+        assertEquals(1, table.model.rowCount, "the pass carrying the change should leave the model with one row")
+    }
+
+    @Test
+    fun aPassThatChangesNoRowNotifiesNothing() = runComposeSwingTest {
+        val rows = mutableStateListOf(Person("Ada", 36))
+        var rowHeight by mutableStateOf(20)
+        setContent {
+            Table(rows = rows, rowHeight = rowHeight) {
+                column("Name") { it.name }
+            }
+        }
+
+        val table = onNodeOfType<JTable>().fetch()
+        val events = mutableListOf<TableModelEvent>()
+        table.model.addTableModelListener(TableModelListener { events += it })
+
+        rowHeight = 24
+        awaitIdle()
+
+        assertEquals(24, table.rowHeight, "the pass this asserts about has to have run")
+        assertTrue(events.isEmpty(), "a pass that changed no row should leave the table alone")
+    }
+}

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TreeBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TreeBehaviorTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.ReusableContentHost
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import javax.swing.JTree
@@ -410,6 +412,24 @@ class TreeBehaviorTest {
             listOf("second selection", "second expansion"),
             reported,
             "a callback the recomposition replaced is not the one that runs",
+        )
+    }
+
+    @Test
+    fun aSelectionTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JTree::class.java,
+            declared = emptyList<Int>(),
+            content = {
+                Tree(
+                    root = "root",
+                    children = { node -> if (node == "root") listOf("one", "two") else emptyList() },
+                    selectedPaths = emptySet(),
+                    onSelectionChange = {},
+                )
+            },
+            move = { it.setSelectionRow(0) },
+            read = { it.selectionRows?.toList().orEmpty() },
         )
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/text/DeclaredTextPushTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/text/DeclaredTextPushTest.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
 import org.jetbrains.compose.swing.node.AppliedValue
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import java.beans.PropertyChangeListener
@@ -391,6 +393,50 @@ class DeclaredTextPushTest {
 
         document.insertString(document.length, "!", null)
         assertEquals(listOf("inner-outer!"), reported, "the edit after the outermost write is reported")
+    }
+
+    @Test
+    fun aTextFieldEditTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JTextField::class.java,
+            declared = "Ada",
+            content = { TextField(value = "Ada", onValueChange = {}) },
+            move = { it.text = "Adam" },
+            read = { it.text },
+        )
+    }
+
+    @Test
+    fun aTextAreaEditTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JTextArea::class.java,
+            declared = "Ada",
+            content = { TextArea(value = "Ada", onValueChange = {}) },
+            move = { it.text = "Adam" },
+            read = { it.text },
+        )
+    }
+
+    @Test
+    fun aTextPaneEditTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JTextPane::class.java,
+            declared = "Ada",
+            content = { TextPane(value = "Ada", onValueChange = {}) },
+            move = { it.text = "Adam" },
+            read = { it.text },
+        )
+    }
+
+    @Test
+    fun aCommitTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JFormattedTextField::class.java,
+            declared = 10,
+            content = { FormattedTextField(value = 10, onValueChange = {}) },
+            move = { it.value = 42 },
+            read = { it.value },
+        )
     }
 }
 

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/text/PasswordFieldBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/text/PasswordFieldBehaviorTest.kt
@@ -3,6 +3,8 @@ package org.jetbrains.compose.swing.components.text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.jetbrains.compose.swing.assertUnadoptedMoveIsPutBack
+import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
 import javax.swing.JPasswordField
@@ -114,6 +116,17 @@ class PasswordFieldBehaviorTest {
         // The wrapper's own mirror listener, attached alongside the caller's raw one, is what keeps the
         // declared value settling back with no onValueChange callback to report through.
         assertEquals("hunter2", String(field.fetch().password))
+    }
+
+    @Test
+    fun anEditTheCallerDoesNotAdoptComesOffWithinEventCycles() = runSwingTest {
+        assertUnadoptedMoveIsPutBack(
+            type = JPasswordField::class.java,
+            declared = "hunter2",
+            content = { PasswordField(value = "hunter2".toCharArray(), onValueChange = {}) },
+            move = { it.text = "hunter3" },
+            read = { String(it.password) },
+        )
     }
 }
 

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/ComponentRecomposerTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/ComponentRecomposerTest.kt
@@ -39,7 +39,7 @@ import kotlin.time.Duration.Companion.seconds
  * caller creates for a component with [SwingRecomposer.create] and disposes itself - and for the
  * boundary between it and the runtime a [java.awt.Window] owns.
  *
- * A component-hosted runtime runs on the Swing frame-clock timer, so the test body runs on the EDT and
+ * A component-hosted runtime recomposes on the event queue, so the test body runs on the EDT and
  * yields it back between checks until a bounded deadline. The cases that need a window realize a real
  * off-screen [JFrame] and skip on a headless environment; the rest run either way, since a
  * component-hosted runtime needs no window at all.
@@ -216,7 +216,7 @@ class ComponentRecomposerTest {
         try {
             assertEquals(FPS_120, island.displayRefreshRate(), "the component under test reports its own rate")
             assertEquals(
-                SwingFrameClock(island.displayRefreshRate()).frameDelayMillis,
+                SwingFrameClock(runtime.recomposer, island.displayRefreshRate()).frameDelayMillis,
                 runtime.clock.frameDelayMillis,
                 "the runtime must pace its clock by the rate its component reports",
             )
@@ -224,7 +224,7 @@ class ComponentRecomposerTest {
             // Moving to a display of another rate is reported as a "graphicsConfiguration" change.
             island.display = FakeDisplayConfiguration(FPS_60)
             assertEquals(
-                SwingFrameClock(island.displayRefreshRate()).frameDelayMillis,
+                SwingFrameClock(runtime.recomposer, island.displayRefreshRate()).frameDelayMillis,
                 runtime.clock.frameDelayMillis,
                 "the runtime must follow its component to a display of a different rate",
             )

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/FrameClockPacingTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/FrameClockPacingTest.kt
@@ -1,0 +1,351 @@
+package org.jetbrains.compose.swing.core
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.jetbrains.compose.swing.components.Label
+import org.jetbrains.compose.swing.runSwingTest
+import org.jetbrains.compose.swing.setContent
+import java.awt.Container
+import javax.swing.JLabel
+import javax.swing.JPanel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Behavioral tests for the two cadences a composition runs on: recomposition, which follows the event
+ * queue, and frame-driven work, which follows the clock.
+ *
+ * These run on a real [SwingRecomposer] with its real timer, since what they pin is timing the test
+ * harness's controllable clock deliberately takes out of the picture. They measure in event-dispatch
+ * cycles rather than milliseconds wherever they can, so a loaded machine slows a case down without
+ * changing what it asserts.
+ */
+class FrameClockPacingTest {
+    @Test
+    fun everyWriteMadeWhileHandlingOneEventCostsASinglePass() = runSwingTest {
+        val island = JPanel()
+        val runtime = SwingRecomposer.create(island)
+        var counter by mutableStateOf(0)
+        var passes = 0
+        var content: DisposableHandle? = null
+        try {
+            content =
+                island.setContent(parent = runtime.compositionContext) {
+                    Label(text = "n=$counter")
+                    SideEffect { passes++ }
+                }
+            awaitUntil("the content mounts") { labelTextOrNull(island) == "n=0" }
+            val passesBefore = passes
+
+            // No suspension point between the writes, so all of them are made while the event
+            // dispatch thread is handling a single event, exactly as a Swing listener would.
+            repeat(WRITES_PER_EVENT) { counter = it + 1 }
+
+            awaitUntil("the writes reach the widget") { labelTextOrNull(island) == "n=$WRITES_PER_EVENT" }
+            delay(QUIET_PERIOD)
+            assertEquals(
+                1,
+                passes - passesBefore,
+                "$WRITES_PER_EVENT writes made under one event must cost one pass, not one pass each",
+            )
+        } finally {
+            content?.dispose()
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun aWriteReachesItsWidgetWithoutWaitingOutAFrame() = runSwingTest {
+        val island = JPanel()
+        val runtime = SwingRecomposer.create(island)
+        var text by mutableStateOf("v0")
+        var content: DisposableHandle? = null
+        try {
+            content = island.setContent(parent = runtime.compositionContext) { Label(text = text) }
+            awaitUntil("the content mounts") { labelTextOrNull(island) == "v0" }
+
+            repeat(WRITES_TIMED) { round ->
+                val expected = "v${round + 1}"
+                text = expected
+                val cycles = cyclesUntil("write $expected reaches the widget") { labelTextOrNull(island) == expected }
+                assertTrue(
+                    cycles <= MAX_CYCLES_TO_APPLY,
+                    "a write must apply on the cycles right after the event that made it, " +
+                        "not a frame interval later; it took $cycles event-dispatch cycles",
+                )
+            }
+        } finally {
+            content?.dispose()
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun anAnimationAdvancesAtTheClockCadenceRatherThanAsFastAsTheEventQueueTurns() = runSwingTest {
+        val island = JPanel()
+        val runtime = SwingRecomposer.create(island)
+        var target by mutableStateOf(0f)
+        val steps = mutableListOf<Float>()
+        var content: DisposableHandle? = null
+        try {
+            content =
+                island.setContent(parent = runtime.compositionContext) {
+                    val fraction = linearRamp(target)
+                    Label(text = "f=$fraction")
+                    SideEffect { if (steps.lastOrNull() != fraction) steps += fraction }
+                }
+            awaitUntil("the content mounts") { steps.isNotEmpty() }
+
+            target = 1f
+            awaitUntil("the animation reaches its target") { steps.last() == 1f }
+
+            val cadenceFrames = ANIMATION_MILLIS / runtime.clock.frameDelayMillis
+            assertTrue(
+                steps.size > 1,
+                "the animation must advance in steps rather than snap to its target; it went $steps",
+            )
+            assertTrue(
+                steps.size <= cadenceFrames * CADENCE_HEADROOM,
+                "a ${ANIMATION_MILLIS}ms animation on a ${runtime.clock.frameDelayMillis}ms cadence takes on " +
+                    "the order of $cadenceFrames steps; ${steps.size} means it ran as fast as the event " +
+                    "queue turned rather than on the clock",
+            )
+            assertTrue(
+                steps.zipWithNext().all { (previous, next) -> next > previous },
+                "a linear animation must advance one way only; it went $steps",
+            )
+            assertTrue(
+                steps.zipWithNext().all { (previous, next) -> next - previous <= MAX_STEP },
+                "no step may jump most of the way at once; it went $steps",
+            )
+        } finally {
+            content?.dispose()
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun aWriteLandingMidAnimationAppliesAtOnceAndTheAnimationNeitherSkipsNorJumps() = runSwingTest {
+        val island = JPanel()
+        val runtime = SwingRecomposer.create(island)
+        var target by mutableStateOf(0f)
+        var counter by mutableStateOf(0)
+        val steps = mutableListOf<Float>()
+        var content: DisposableHandle? = null
+        try {
+            content =
+                island.setContent(parent = runtime.compositionContext) {
+                    val fraction = linearRamp(target)
+                    Label(text = "n=$counter f=$fraction")
+                    SideEffect { if (steps.lastOrNull() != fraction) steps += fraction }
+                }
+            awaitUntil("the content mounts") { steps.isNotEmpty() }
+
+            target = 1f
+            // Write on every cycle for as long as the animation runs: each write lands between two
+            // animation frames, which is the case the paused clock has to serve.
+            var writes = 0
+            var worstCycles = 0
+            while (steps.last() != 1f) {
+                counter = ++writes
+                worstCycles =
+                    maxOf(
+                        worstCycles,
+                        cyclesUntil("write $writes reaches the widget") {
+                            labelTextOrNull(island)?.startsWith("n=$writes ") == true
+                        },
+                    )
+            }
+
+            assertTrue(writes > 1, "the case needs writes made while the animation was still running")
+            assertTrue(
+                worstCycles <= MAX_CYCLES_TO_APPLY,
+                "a write made mid-animation must not wait for the animation's next frame; " +
+                    "the slowest took $worstCycles event-dispatch cycles",
+            )
+            val cadenceFrames = ANIMATION_MILLIS / runtime.clock.frameDelayMillis
+            assertTrue(
+                steps.size <= cadenceFrames * CADENCE_HEADROOM,
+                "writes must not smuggle extra animation frames in: a ${ANIMATION_MILLIS}ms animation " +
+                    "took ${steps.size} steps against $writes writes",
+            )
+            assertTrue(
+                steps.zipWithNext().all { (previous, next) -> next > previous && next - previous <= MAX_STEP },
+                "the animation must neither run backwards nor jump; it went $steps",
+            )
+        } finally {
+            content?.dispose()
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun workThatStartsAwaitingFramesLongAfterTheLastOneStillGetsThem() = runSwingTest {
+        val island = JPanel()
+        val runtime = SwingRecomposer.create(island)
+        var framesSeen by mutableStateOf(0)
+        var content: DisposableHandle? = null
+        try {
+            content =
+                island.setContent(parent = runtime.compositionContext) {
+                    Label(text = "frames=$framesSeen")
+                    LaunchedEffect(Unit) {
+                        // The composition is fully settled and asking for nothing by the time this
+                        // starts awaiting frames.
+                        delay(LATE_START)
+                        repeat(LATE_FRAMES) {
+                            withFrameNanos { framesSeen++ }
+                        }
+                    }
+                }
+            awaitUntil("the content mounts") { labelTextOrNull(island) == "frames=0" }
+            delay(LATE_START)
+            assertEquals(0, framesSeen, "the case needs the composition idle when the frame awaiting starts")
+
+            awaitUntil("frame-driven work started from an idle composition runs") { framesSeen == LATE_FRAMES }
+        } finally {
+            content?.dispose()
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun anIdleCompositionKeepsNoTimerRunning() = runSwingTest {
+        val island = JPanel()
+        val runtime = SwingRecomposer.create(island)
+        var target by mutableStateOf(0f)
+        val steps = mutableListOf<Float>()
+        var content: DisposableHandle? = null
+        try {
+            content =
+                island.setContent(parent = runtime.compositionContext) {
+                    val fraction = linearRamp(target)
+                    Label(text = "f=$fraction")
+                    SideEffect { if (steps.lastOrNull() != fraction) steps += fraction }
+                }
+            awaitUntil("the content mounts") { steps.isNotEmpty() }
+            assertTrue(
+                !runtime.clock.isPacingFrameDrivenWork,
+                "a composition that has only ever recomposed must run no timer",
+            )
+
+            target = 1f
+            awaitUntil("the animation is running") { steps.size > 1 }
+            assertTrue(runtime.clock.isPacingFrameDrivenWork, "an animation must be paced by the timer")
+
+            awaitUntil("the animation ends and the timer stops") {
+                steps.last() == 1f && !runtime.clock.isPacingFrameDrivenWork
+            }
+        } finally {
+            content?.dispose()
+            runtime.dispose()
+        }
+    }
+
+    /**
+     * A frame-driven stand-in for an animation, so these tests pin the clock rather than an animation
+     * engine: each time [target] moves, it walks from the value it holds to [target] over
+     * [ANIMATION_MILLIS], one step per frame the clock sends. It lands on [target] exactly and then
+     * awaits no further frame, so a settled ramp asks the clock for nothing.
+     */
+    @Composable
+    private fun linearRamp(target: Float): Float {
+        var value by remember { mutableStateOf(target) }
+        LaunchedEffect(target) {
+            val start = value
+            if (start == target) return@LaunchedEffect
+            val startNanos = withFrameNanos { it }
+            var elapsed = 0L
+            while (elapsed < ANIMATION_NANOS) {
+                elapsed = withFrameNanos { it } - startNanos
+                val progress = (elapsed.toFloat() / ANIMATION_NANOS).coerceAtMost(1f)
+                value = start + (target - start) * progress
+            }
+        }
+        return value
+    }
+
+    /**
+     * Suspends on the EDT until [condition] holds, yielding the EDT back between checks so the
+     * composition can make progress, and answers how many cycles that took. A condition that never
+     * becomes true fails the test at the deadline, naming [description], instead of hanging.
+     */
+    private suspend fun cyclesUntil(
+        description: String,
+        condition: () -> Boolean,
+    ): Int {
+        var cycles = 0
+        try {
+            withTimeout(SETTLE_TIMEOUT) {
+                while (!condition()) {
+                    cycles++
+                    yield()
+                }
+            }
+        } catch (timedOut: TimeoutCancellationException) {
+            throw AssertionError("Timed out after $SETTLE_TIMEOUT waiting until $description", timedOut)
+        }
+        return cycles
+    }
+
+    private suspend fun awaitUntil(
+        description: String,
+        condition: () -> Boolean,
+    ) {
+        cyclesUntil(description, condition)
+    }
+
+    /** The single [JLabel]'s text in [container]'s subtree, or `null` while none has mounted yet. */
+    private fun labelTextOrNull(container: Container): String? {
+        val labels = mutableListOf<JLabel>()
+
+        fun visit(c: Container) {
+            for (child in c.components) {
+                if (child is JLabel) labels += child
+                if (child is Container) visit(child)
+            }
+        }
+        visit(container)
+        return labels.singleOrNull()?.text
+    }
+
+    private companion object {
+        const val WRITES_PER_EVENT: Int = 10
+        const val WRITES_TIMED: Int = 20
+
+        /**
+         * The event-dispatch cycles a write may take to reach its widget. A write travels through the
+         * snapshot apply notification, the recomposer waking, and the frame that follows the event -
+         * a handful of cycles - while a write held back to a frame interval spends thousands here.
+         */
+        const val MAX_CYCLES_TO_APPLY: Int = 50
+        const val ANIMATION_MILLIS: Int = 400
+        const val ANIMATION_NANOS: Long = ANIMATION_MILLIS * 1_000_000L
+
+        /**
+         * How far over the nominal step count a run may go before it is no longer clock-paced. The
+         * cadence is nominal and jitters with load, so the bound is loose; free-running work overruns
+         * it by two orders of magnitude rather than by a factor.
+         */
+        const val CADENCE_HEADROOM: Int = 4
+        const val LATE_FRAMES: Int = 3
+        const val MAX_STEP: Float = 0.5f
+        val LATE_START = 300.milliseconds
+        val QUIET_PERIOD = 200.milliseconds
+        val SETTLE_TIMEOUT = 10.seconds
+    }
+}

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/NestedMountParentTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/NestedMountParentTest.kt
@@ -1,0 +1,300 @@
+package org.jetbrains.compose.swing.core
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.jetbrains.compose.swing.components.Label
+import org.jetbrains.compose.swing.node.SwingNode
+import org.jetbrains.compose.swing.runSwingTest
+import org.jetbrains.compose.swing.setContent
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import java.awt.Container
+import java.awt.GraphicsEnvironment
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Behavioral tests for the composition a `setContent` nested inside an island joins.
+ *
+ * An island mounted under a caller's own [androidx.compose.runtime.CompositionContext] governs
+ * everything mounted inside it: a container that hangs under such an island composes on the runtime the
+ * island was given, not on the one its window happens to own - whether the mount is made during the
+ * island's own first pass, once that pass has put the container in place, or before a later
+ * recomposition inserts it. Where no island stands in the way, a container joins the composition its
+ * window shares, which is what every parentless mount resolves to.
+ *
+ * Which runtime a mount joined is read off what it does: the runtime the island was given is disposed,
+ * and content that joined it stops recomposing while a sibling on the window's own runtime goes on.
+ *
+ * Each case realizes a real top-level peer, so each skips on a headless environment.
+ */
+class NestedMountParentTest {
+    @Test
+    fun aNestedMountMadeDuringTheIslandsFirstPassJoinsTheRuntimeItsIslandWasGiven() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display to realize a window")
+        val frame = realizedFrame()
+        val runtime = SwingRecomposer.create(JPanel())
+        val island = JPanel().also { frame.contentPane.add(it) }
+        val windowIsland = JPanel().also { frame.contentPane.add(it) }
+        val nested = JPanel()
+        var text by mutableStateOf("v0")
+        var islandHandle: DisposableHandle? = null
+        var windowHandle: DisposableHandle? = null
+        try {
+            islandHandle =
+                island.setContent(parent = runtime.compositionContext) {
+                    SwingNode(factory = { nested })
+                    // The nested mount is made from an effect of the island's own first pass, before that
+                    // pass has returned, so it resolves its parent while the island is still composing.
+                    // The island's composition owns it, and ends it.
+                    DisposableEffect(Unit) {
+                        val handle = nested.setContent { Label(text = text) }
+                        onDispose { handle.dispose() }
+                    }
+                }
+            windowHandle = windowIsland.setContent { Label(text = text) }
+            awaitUntil("both contents render") {
+                labelTexts(nested) == listOf("v0") && labelTexts(windowIsland) == listOf("v0")
+            }
+            assertSame(island, nested.parent, "the island's first pass composed the nested container into place")
+
+            runtime.dispose()
+            text = "v1"
+            awaitUntil("the window's own island recomposes") { labelTexts(windowIsland) == listOf("v1") }
+            delay(QUIET_PERIOD)
+            assertEquals(
+                listOf("v0"),
+                labelTexts(nested),
+                "content mounted during the island's first pass must recompose on the runtime that island " +
+                    "was given, not on the window's",
+            )
+        } finally {
+            islandHandle?.dispose()
+            windowHandle?.dispose()
+            runtime.dispose()
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun aNestedMountWithNoIslandAboveItJoinsItsWindow() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display to realize a window")
+        val frame = realizedFrame()
+        val island = JPanel().also { frame.contentPane.add(it) }
+        val nested = JPanel()
+        var islandHandle: DisposableHandle? = null
+        var nestedHandle: DisposableHandle? = null
+        try {
+            islandHandle = island.setContent { SwingNode(factory = { nested }) }
+            awaitUntil("the island composes its nested container into place") { nested.parent === island }
+
+            nestedHandle = nested.setContent { Label(text = "nested") }
+            awaitUntil("the nested content renders") { labelTexts(nested) == listOf("nested") }
+
+            assertSame(
+                frame.compositionContext(),
+                nested.findParentCompositionContext(),
+                "a mount under an island that named no parent must join the window's shared composition",
+            )
+        } finally {
+            nestedHandle?.dispose()
+            islandHandle?.dispose()
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun aNestedMountInsertedByALaterRecompositionJoinsTheRuntimeItsIslandWasGiven() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display to realize a window")
+        val frame = realizedFrame()
+        val runtime = SwingRecomposer.create(JPanel())
+        val island = JPanel().also { frame.contentPane.add(it) }
+        val windowIsland = JPanel().also { frame.contentPane.add(it) }
+        val nested = JPanel()
+        var showNested by mutableStateOf(false)
+        var text by mutableStateOf("v0")
+        var islandHandle: DisposableHandle? = null
+        var nestedHandle: DisposableHandle? = null
+        var windowHandle: DisposableHandle? = null
+        try {
+            islandHandle =
+                island.setContent(parent = runtime.compositionContext) {
+                    Label(text = "island")
+                    if (showNested) SwingNode(factory = { nested })
+                }
+            windowHandle = windowIsland.setContent { Label(text = text) }
+            awaitUntil("the island composes without the nested container") { labelTexts(island) == listOf("island") }
+
+            // The mount is made while the container hangs nowhere, so it waits for a place; the place it
+            // then takes is one a later recomposition gives it.
+            nestedHandle = nested.setContent { Label(text = text) }
+            showNested = true
+
+            awaitUntil("a later recomposition inserts the nested container") { nested.parent === island }
+            awaitUntil("both contents render") {
+                labelTexts(nested) == listOf("v0") && labelTexts(windowIsland) == listOf("v0")
+            }
+            assertEquals(listOf("island", "v0"), labelTexts(island), "the island holds what both mounts composed")
+
+            runtime.dispose()
+            text = "v1"
+            awaitUntil("the window's own island recomposes") { labelTexts(windowIsland) == listOf("v1") }
+            delay(QUIET_PERIOD)
+            assertEquals(
+                listOf("v0"),
+                labelTexts(nested),
+                "content a later recomposition places inside an island must recompose on the runtime that " +
+                    "island was given, not on the window's",
+            )
+        } finally {
+            nestedHandle?.dispose()
+            windowHandle?.dispose()
+            islandHandle?.dispose()
+            runtime.dispose()
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun nestedContentRecomposesOnTheRuntimeItsIslandWasGiven() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display to realize a window")
+        val frame = realizedFrame()
+        val runtime = SwingRecomposer.create(JPanel())
+        val island = JPanel().also { frame.contentPane.add(it) }
+        val windowIsland = JPanel().also { frame.contentPane.add(it) }
+        val nested = JPanel()
+        var text by mutableStateOf("v0")
+        var islandHandle: DisposableHandle? = null
+        var nestedHandle: DisposableHandle? = null
+        var windowHandle: DisposableHandle? = null
+        try {
+            islandHandle = island.setContent(parent = runtime.compositionContext) { SwingNode(factory = { nested }) }
+            windowHandle = windowIsland.setContent { Label(text = text) }
+            awaitUntil("the island composes its nested container into place") { nested.parent === island }
+
+            nestedHandle = nested.setContent { Label(text = text) }
+            awaitUntil("both contents render") {
+                labelTexts(nested) == listOf("v0") && labelTexts(windowIsland) == listOf("v0")
+            }
+
+            // Only the runtime the island was given is disposed. Content that joined it stops recomposing;
+            // content that joined the window goes on.
+            runtime.dispose()
+            text = "v1"
+            awaitUntil("the window's own island recomposes") { labelTexts(windowIsland) == listOf("v1") }
+            delay(QUIET_PERIOD)
+            assertEquals(
+                listOf("v0"),
+                labelTexts(nested),
+                "nested content must recompose on the runtime its island was given, not on the window's",
+            )
+        } finally {
+            nestedHandle?.dispose()
+            windowHandle?.dispose()
+            islandHandle?.dispose()
+            runtime.dispose()
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun aNestedMountFollowsItsContainersMoveToAnotherWindowAndOutlivesTheOneItLeft() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display to realize a window")
+        val first = realizedFrame()
+        val second = realizedFrame()
+        val outer = JPanel().also { first.contentPane.add(it) }
+        val inner = JPanel()
+        var text by mutableStateOf("v0")
+        var outerHandle: DisposableHandle? = null
+        var innerHandle: DisposableHandle? = null
+        try {
+            outerHandle = outer.setContent { SwingNode(factory = { inner }) }
+            awaitUntil("the outer island composes the nested container into place") { inner.parent === outer }
+
+            innerHandle = inner.setContent { Label(text = text) }
+            awaitUntil("the nested content renders") { labelTexts(inner) == listOf("v0") }
+
+            second.contentPane.add(outer)
+            second.pack()
+            awaitUntil("the outer container is in the second window") {
+                SwingUtilities.getWindowAncestor(outer) === second
+            }
+
+            // The window the nested content started in owns the recomposer it composed on; disposing that
+            // window must not silence a container that has moved on to another one.
+            first.dispose()
+            text = "v1"
+            awaitUntil("the nested content recomposes in the window it moved to") {
+                labelTexts(inner) == listOf("v1")
+            }
+        } finally {
+            innerHandle?.dispose()
+            outerHandle?.dispose()
+            second.dispose()
+            first.dispose()
+        }
+    }
+
+    /**
+     * A realized, off-screen [JFrame] with a live peer. Packing realizes the peer without showing the
+     * frame. Must be called on the EDT.
+     */
+    private fun realizedFrame(): JFrame = JFrame().apply {
+        defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+        pack()
+    }
+
+    /** The text of every [JLabel] in [container]'s subtree, in tree order. Must be called on the EDT. */
+    private fun labelTexts(container: Container): List<String> {
+        val texts = mutableListOf<String>()
+
+        fun visit(c: Container) {
+            for (child in c.components) {
+                if (child is JLabel) texts += child.text
+                if (child is Container) visit(child)
+            }
+        }
+        visit(container)
+        return texts
+    }
+
+    /**
+     * Suspends on the EDT until [condition] holds, yielding the EDT back between checks so a window's
+     * real frame-clock timer can fire and its recomposer can mount and recompose content. A condition
+     * that never holds fails the test at the deadline, naming [description], instead of hanging.
+     */
+    private suspend fun awaitUntil(
+        description: String,
+        condition: () -> Boolean,
+    ) {
+        try {
+            withTimeout(SETTLE_TIMEOUT) {
+                while (!condition()) {
+                    yield()
+                }
+            }
+        } catch (timedOut: TimeoutCancellationException) {
+            throw AssertionError("Timed out after $SETTLE_TIMEOUT waiting until $description", timedOut)
+        }
+    }
+
+    private companion object {
+        val SETTLE_TIMEOUT = 10.seconds
+
+        /** Spans many frame intervals, so a runtime still running would have applied a change well inside it. */
+        val QUIET_PERIOD = 300.milliseconds
+    }
+}

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/NestedMountParentTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/NestedMountParentTest.kt
@@ -248,6 +248,69 @@ class NestedMountParentTest {
         }
     }
 
+    @Test
+    fun aNestedMountStaysOnItsIslandsRuntimeWhenItsContainerMovesToAnotherWindow() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display to realize a window")
+        val first = realizedFrame()
+        val second = realizedFrame()
+        val runtime = SwingRecomposer.create(JPanel())
+        val outer = JPanel().also { first.contentPane.add(it) }
+        val windowIsland = JPanel().also { first.contentPane.add(it) }
+        val inner = JPanel()
+        var text by mutableStateOf("v0")
+        var outerHandle: DisposableHandle? = null
+        var innerHandle: DisposableHandle? = null
+        var windowHandle: DisposableHandle? = null
+        try {
+            outerHandle = outer.setContent(parent = runtime.compositionContext) { SwingNode(factory = { inner }) }
+            windowHandle = windowIsland.setContent { Label(text = text) }
+            awaitUntil("the outer island composes the nested container into place") { inner.parent === outer }
+
+            innerHandle = inner.setContent { Label(text = text) }
+            awaitUntil("both contents render") {
+                labelTexts(inner) == listOf("v0") && labelTexts(windowIsland) == listOf("v0")
+            }
+
+            second.contentPane.add(outer)
+            second.pack()
+            awaitUntil("the outer container is in the second window") {
+                SwingUtilities.getWindowAncestor(outer) === second
+            }
+            // The nested mount's rejoin is queued behind the reparenting event rather than run inline, so
+            // a quiet period here lets it settle before the container moves again.
+            delay(QUIET_PERIOD)
+
+            // Moved a second time, back to the window it started in: the nested mount is asked to resolve
+            // its parent again, so this is what tells a caller's runtime read fresh on every move from one
+            // that only ever happened to be read on the move that settled first.
+            first.contentPane.add(outer)
+            awaitUntil("the outer container is back in the first window") {
+                SwingUtilities.getWindowAncestor(outer) === first
+            }
+            delay(QUIET_PERIOD)
+
+            // Only the runtime the outer island was given is disposed. The nested content that joined it
+            // must stop recomposing, while a sibling on the window's own runtime goes on.
+            runtime.dispose()
+            text = "v1"
+            awaitUntil("the window's own island recomposes") { labelTexts(windowIsland) == listOf("v1") }
+            delay(QUIET_PERIOD)
+            assertEquals(
+                listOf("v0"),
+                labelTexts(inner),
+                "a nested mount must stay on the runtime its island was given after the island's container " +
+                    "moves to another window",
+            )
+        } finally {
+            innerHandle?.dispose()
+            windowHandle?.dispose()
+            outerHandle?.dispose()
+            runtime.dispose()
+            second.dispose()
+            first.dispose()
+        }
+    }
+
     /**
      * A realized, off-screen [JFrame] with a live peer. Packing realizes the peer without showing the
      * frame. Must be called on the EDT.

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SetContentMisuseTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SetContentMisuseTest.kt
@@ -1,8 +1,15 @@
 package org.jetbrains.compose.swing.core
 
+import androidx.compose.runtime.Recomposer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.yield
 import org.jetbrains.compose.swing.components.Label
 import org.jetbrains.compose.swing.runSwingTest
 import org.jetbrains.compose.swing.setContent
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import java.awt.GraphicsEnvironment
+import javax.swing.JFrame
 import javax.swing.JPanel
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,10 +19,12 @@ import kotlin.test.assertTrue
 /**
  * What `setContent` refuses, and what it must go on accepting.
  *
- * A container that already holds a live island is asked once for the composition its contents nest
- * into, and cannot give two answers. Such a call fails on the call.
+ * Two things make a call unanswerable rather than merely unusual. A container that already holds a live
+ * island is asked once for the composition its contents nest into, and cannot give two answers. A named
+ * parent whose runtime has ended would never recompose what is composed under it. Both fail on the
+ * call.
  *
- * The case that refuses is paired with the nearest legal call, because a check that fires on a legal
+ * Each case that refuses is paired with the nearest legal call, because a check that fires on a legal
  * transition is worse than the misuse it guards against.
  */
 class SetContentMisuseTest {
@@ -54,5 +63,94 @@ class SetContentMisuseTest {
         } finally {
             runtime.dispose()
         }
+    }
+
+    @Test
+    fun aRuntimeThatHasBeenDisposedIsRefusedAsAParent() = runSwingTest {
+        val panel = JPanel()
+        val runtime = SwingRecomposer.create(panel)
+        val ended = runtime.compositionContext
+        runtime.dispose()
+
+        val refused =
+            assertFailsWith<IllegalStateException> {
+                panel.setContent(parent = ended) { Label(text = "never composes") }
+            }
+        assertTrue(
+            "would never recompose" in refused.message.orEmpty(),
+            "the refusal must say what composing under an ended runtime would cost, and said: ${refused.message}",
+        )
+        assertEquals(0, panel.componentCount, "a refused mount must leave the container empty")
+        assertEquals(0, panel.hierarchyListeners.size, "a refused mount must leave no listener behind")
+    }
+
+    @Test
+    fun aRuntimeThatIsStillLiveIsAcceptedAsAParent() = runSwingTest {
+        val panel = JPanel()
+        val runtime = SwingRecomposer.create(panel)
+        try {
+            // A runtime stands at Inactive between being created and its coroutine running, which is not
+            // an ended one. Naming it on the call after create() is the transition the check must pass.
+            panel.setContent(parent = runtime.compositionContext) { Label(text = "composes") }
+
+            assertEquals(1, panel.componentCount, "a live runtime must compose the content it was named for")
+        } finally {
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun aRuntimeCancelledBeforeItEverRecomposedIsRefusedAsAParent() = runSwingTest {
+        // A runtime cancelled before it ever recomposed reaches an ended state through its effect job
+        // completing rather than through the cancel itself, so this pins that a runtime which never ran
+        // is refused too - not only one that ran and was then stopped.
+        val neverRan = Recomposer(Dispatchers.Swing)
+        neverRan.cancel()
+
+        val panel = JPanel()
+        val refused =
+            assertFailsWith<IllegalStateException> {
+                panel.setContent(parent = neverRan) { Label(text = "never composes") }
+            }
+        assertTrue(
+            "would never recompose" in refused.message.orEmpty(),
+            "a cancelled runtime must be refused whatever state it reports, and said: ${refused.message}",
+        )
+    }
+
+    @Test
+    fun theContextOfAClosedWindowIsRefusedAsAParent() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display")
+        val frame = JFrame().apply { pack() }
+        val ended = frame.compositionContext()
+        val listenersHeld = frame.windowListeners.size
+
+        // Disposing the window ends the runtime it owns and takes the listener naming that runtime off
+        // the window, which is what would otherwise leave this context looking like a runtime standing on
+        // its own. dispose() posts that event rather than delivering it, so the queue is drained first:
+        // until it is, the runtime is still live and still findable, and refusing the mount would be
+        // wrong.
+        frame.dispose()
+        var cycles = 0
+        while (frame.windowListeners.size == listenersHeld && cycles++ < CLOSE_CYCLES) yield()
+        assertTrue(
+            frame.windowListeners.size < listenersHeld,
+            "the window must finish closing before this asserts what a closed window's context does",
+        )
+
+        val panel = JPanel()
+        val refused =
+            assertFailsWith<IllegalStateException> {
+                panel.setContent(parent = ended) { Label(text = "never composes") }
+            }
+        assertTrue(
+            "would never recompose" in refused.message.orEmpty(),
+            "a closed window's context must be refused as an ended runtime, and said: ${refused.message}",
+        )
+    }
+
+    private companion object {
+        /** Event-dispatch cycles a window's own teardown may take after `dispose()` posts it. */
+        const val CLOSE_CYCLES: Int = 50
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SetContentMisuseTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SetContentMisuseTest.kt
@@ -1,0 +1,58 @@
+package org.jetbrains.compose.swing.core
+
+import org.jetbrains.compose.swing.components.Label
+import org.jetbrains.compose.swing.runSwingTest
+import org.jetbrains.compose.swing.setContent
+import javax.swing.JPanel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * What `setContent` refuses, and what it must go on accepting.
+ *
+ * A container that already holds a live island is asked once for the composition its contents nest
+ * into, and cannot give two answers. Such a call fails on the call.
+ *
+ * The case that refuses is paired with the nearest legal call, because a check that fires on a legal
+ * transition is worse than the misuse it guards against.
+ */
+class SetContentMisuseTest {
+    @Test
+    fun aContainerAlreadyHoldingALiveIslandRefusesMoreContent() = runSwingTest {
+        val panel = JPanel()
+        val runtime = SwingRecomposer.create(panel)
+        try {
+            panel.setContent(parent = runtime.compositionContext) { Label(text = "first") }
+
+            val refused =
+                assertFailsWith<IllegalStateException> {
+                    panel.setContent(parent = runtime.compositionContext) { Label(text = "second") }
+                }
+            assertTrue(
+                "two islands cannot both be" in refused.message.orEmpty(),
+                "the refusal must say why a container answers for one island only, and said: ${refused.message}",
+            )
+        } finally {
+            runtime.dispose()
+        }
+    }
+
+    @Test
+    fun aContainerWhoseIslandWasDisposedTakesContentAgain() = runSwingTest {
+        val panel = JPanel()
+        val runtime = SwingRecomposer.create(panel)
+        try {
+            val first = panel.setContent(parent = runtime.compositionContext) { Label(text = "first") }
+            first.dispose()
+
+            // Only a live island stands in the way, so the container answers for this one now.
+            panel.setContent(parent = runtime.compositionContext) { Label(text = "second") }
+
+            assertEquals(1, panel.componentCount, "the container should hold the content mounted second")
+        } finally {
+            runtime.dispose()
+        }
+    }
+}

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SetContentParentWindowTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SetContentParentWindowTest.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import org.jetbrains.compose.swing.components.Label
@@ -31,12 +32,14 @@ import javax.swing.CellRendererPane
 import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.SwingUtilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /** A [androidx.compose.runtime.CompositionLocal] a host composition provides to whatever nests into it. */
@@ -556,6 +559,52 @@ class SetContentParentWindowTest {
     }
 
     @Test
+    fun anIslandGivenItsOwnRuntimeKeepsItAcrossAWindowMove() = runSwingTest {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display")
+        val first = realizedFrame()
+        val second = realizedFrame()
+        val runtime = SwingRecomposer.create(JPanel())
+        val island = JPanel().also { first.contentPane.add(it) }
+        val windowIsland = JPanel().also { first.contentPane.add(it) }
+        var text by mutableStateOf("v0")
+        var islandHandle: DisposableHandle? = null
+        var windowHandle: DisposableHandle? = null
+        try {
+            // A runtime of its own belongs to no window, so the move a container carrying it makes between
+            // windows is nothing the composition it belongs to has to account for.
+            islandHandle = island.setContent(parent = runtime.compositionContext) { Label(text = text) }
+            windowHandle = windowIsland.setContent { Label(text = text) }
+            awaitUntil("both islands render") {
+                labelTexts(island) == listOf("v0") && labelTexts(windowIsland) == listOf("v0")
+            }
+
+            second.contentPane.add(island)
+            second.pack()
+            awaitUntil("the island is in the second window") {
+                SwingUtilities.getWindowAncestor(island) === second
+            }
+
+            // Only the caller's runtime is disposed. An island that kept it must stop recomposing;
+            // the window's own island goes on.
+            runtime.dispose()
+            text = "v1"
+            awaitUntil("the window's own island recomposes") { labelTexts(windowIsland) == listOf("v1") }
+            delay(QUIET_PERIOD)
+            assertEquals(
+                listOf("v0"),
+                labelTexts(island),
+                "an island given its own runtime must keep it across a window move, not join the window",
+            )
+        } finally {
+            islandHandle?.dispose()
+            windowHandle?.dispose()
+            runtime.dispose()
+            second.dispose()
+            first.dispose()
+        }
+    }
+
+    @Test
     fun anIslandReadsALifecycleOwnerProvidedOverTheCompositionItJoins() = runSwingTest {
         assumeFalse(GraphicsEnvironment.isHeadless(), "requires a display")
         val frame = realizedFrame()
@@ -783,6 +832,10 @@ class SetContentParentWindowTest {
 
     private companion object {
         val SETTLE_TIMEOUT = 10.seconds
+
+        /** Spans many frame intervals, so a runtime still running would have applied a change well inside it. */
+        val QUIET_PERIOD = 300.milliseconds
+
         const val CELL_SIDE: Int = 40
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SwingFrameClockRetimeTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SwingFrameClockRetimeTest.kt
@@ -45,7 +45,7 @@ class SwingFrameClockRetimeTest {
         val clock = clockAt(FPS_60)
         clock.setFramesPerSecond(0)
         assertEquals(
-            MILLIS_PER_SECOND,
+            MILLIS_AT_1_FPS,
             clock.frameDelayMillis,
             "a non-positive fps must not divide by zero; it falls back to one frame per second",
         )
@@ -90,6 +90,6 @@ class SwingFrameClockRetimeTest {
         const val FPS_120: Int = 120
         const val MILLIS_AT_60: Int = 16
         const val MILLIS_AT_120: Int = 8
-        const val MILLIS_PER_SECOND: Int = 1000
+        const val MILLIS_AT_1_FPS: Int = 1000
     }
 }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SwingFrameClockRetimeTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/core/SwingFrameClockRetimeTest.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.compose.swing.core
 
+import androidx.compose.runtime.Recomposer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.swing.Swing
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
 import javax.swing.SwingUtilities
@@ -21,13 +24,13 @@ import kotlin.test.assertEquals
 class SwingFrameClockRetimeTest {
     @Test
     fun framesPerSecondMapsToTimerDelay() = onEdt {
-        assertEquals(MILLIS_AT_60, SwingFrameClock(FPS_60).frameDelayMillis, "60 fps should map to a ~16 ms cadence")
-        assertEquals(MILLIS_AT_120, SwingFrameClock(FPS_120).frameDelayMillis, "120 fps should map to a ~8 ms cadence")
+        assertEquals(MILLIS_AT_60, clockAt(FPS_60).frameDelayMillis, "60 fps should map to a ~16 ms cadence")
+        assertEquals(MILLIS_AT_120, clockAt(FPS_120).frameDelayMillis, "120 fps should map to a ~8 ms cadence")
     }
 
     @Test
     fun setFramesPerSecondRecomputesTheDelay() = onEdt {
-        val clock = SwingFrameClock(FPS_60)
+        val clock = clockAt(FPS_60)
         assertEquals(MILLIS_AT_60, clock.frameDelayMillis, "the clock should start at the 60 fps cadence")
 
         clock.setFramesPerSecond(FPS_120)
@@ -39,7 +42,7 @@ class SwingFrameClockRetimeTest {
 
     @Test
     fun nonPositiveFramesPerSecondIsCoercedToAtLeastOneFrame() = onEdt {
-        val clock = SwingFrameClock(FPS_60)
+        val clock = clockAt(FPS_60)
         clock.setFramesPerSecond(0)
         assertEquals(
             MILLIS_PER_SECOND,
@@ -53,7 +56,7 @@ class SwingFrameClockRetimeTest {
         // Models the wiring SwingRecomposer.create installs: a "graphicsConfiguration" listener that
         // retimes the clock from the event's new value, standing in for a real window's
         // displayRefreshRate() call, which needs a realized Window on a display.
-        val clock = SwingFrameClock(FPS_60)
+        val clock = clockAt(FPS_60)
         val listener = PropertyChangeListener { event -> clock.setFramesPerSecond(event.newValue as Int) }
 
         listener.propertyChange(
@@ -66,6 +69,13 @@ class SwingFrameClockRetimeTest {
             "firing a graphicsConfiguration change to a 120 Hz display should retime the clock to ~8 ms",
         )
     }
+
+    /**
+     * A clock over a recomposer that is never started: the cadence arithmetic these cases cover is the
+     * clock's own, and the recomposer takes no part in it.
+     */
+    private fun clockAt(framesPerSecond: Int): SwingFrameClock =
+        SwingFrameClock(Recomposer(Dispatchers.Swing), framesPerSecond)
 
     private fun <T> onEdt(action: () -> T): T {
         if (SwingUtilities.isEventDispatchThread()) return action()

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/appearance/HighlightsModifierTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/appearance/HighlightsModifierTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.compose.swing.modifier.appearance
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import org.jetbrains.compose.swing.components.text.TextArea
@@ -56,6 +57,25 @@ class HighlightsModifierTest {
             listOf(6 to 11),
             area.paintedSpans(),
             "the new declaration should replace the previous marks rather than accumulate onto them",
+        )
+    }
+
+    @Test
+    fun aDeclaredStateListIsFollowedWhenTheCallerMutatesIt() = runComposeSwingTest {
+        val ranges = mutableStateListOf(TextRange(0, 5))
+        setContent {
+            TextArea(value = TEXT, onValueChange = {}, modifier = SwingModifier.highlights(ranges, Painter))
+        }
+        val area = onNodeOfType<JTextArea>().fetch()
+        assertEquals(listOf(0 to 5), area.paintedSpans(), "the first declaration should be painted")
+
+        ranges.add(TextRange(6, 11))
+        awaitIdle()
+
+        assertEquals(
+            listOf(0 to 5, 6 to 11),
+            area.paintedSpans(),
+            "a range added to the declared list should be painted",
         )
     }
 


### PR DESCRIPTION
Four ways a declaration failed to reach the thing it named, or reached it too late.

### Late
 Recomposition ran on the timer that paces animation, so a state write waited for a frame before reaching its widget. That timer runs only while something awaits a frame, so a write to an idle composition did not join a period already running — it started one, and paid it in full: 16.7 ms at 60 Hz, against nothing at all for the Swing setter it stands in for. It is about 0.2 ms now. Recomposition follows the event queue; animation still advances at the display's rate, and a write landing mid-animation neither skips a frame nor takes an extra one.
 The visible form was a move the user makes and the caller refuses: the widget held the rejected value for longer than a display refresh, so it was scanned out and read as a flicker. This bounds how long that value survives, not the order it comes off in — Swing queues the repaint from inside the event that moves the widget, so the value is painted once either way.

### On the wrong composition
 Content mounted inside a `setContent` island joined the window's composition instead of the one its island was given, so a caller who supplied a parent did not get it for anything nested inside. Separately, a container carrying a nested island stranded that island on the window it was leaving whenever it moved, because Swing delivers a parent change to a container's descendants before the container itself.
 A container that already carries a live island now refuses a second `setContent` rather than leaving the answer to whichever registered first.

### On a composition that had gone
 A container mounted under a caller-created runtime re-resolved its parent from the Swing tree when it moved between windows, silently leaving that runtime for the new window's recomposer. Its content then froze when the caller disposed the runtime it had given. Such a runtime serves content standing outside any window, so where its container hangs is something the content reads, never what decides which composition it belongs to. A context taken from inside another composition still follows windows, because it is torn down with the composition it came from.

### Not at all
 A caller keeping a snapshot list and mutating it in place saw nothing change: the composition never read the items, so nothing invalidated it. `ComboBox`, `Spinner`, `ListBox`, `Table` and the highlights modifier now follow such a list.