### PR TITLE
Add and enforce Compose Swing static analysis

### DIFF
--- a/.agents/skills/verify-code-quality/SKILL.md
+++ b/.agents/skills/verify-code-quality/SKILL.md
@@ -87,7 +87,8 @@ feature or standard-library API fails to compile even on a current JDK.
 
 ## Configuration
 
-- detekt: `config/detekt/detekt.yml`, layered on the default config.
+- detekt: `config/detekt/detekt.yml`, layered on the default config and on the defaults
+  `:swing-ui-detekt` ships. The file states the reason for each rule it turns off.
 - Android Lint, hosting the Compose lint checks: `config/lint/lint.xml`. The file states the reason
   for each check it disables.
 - Coverage floors and ABI filters: each module's `build.gradle.kts`.

--- a/.agents/skills/verify-code-quality/SKILL.md
+++ b/.agents/skills/verify-code-quality/SKILL.md
@@ -82,7 +82,7 @@ Two kinds of declaration are outside the dumps, so the gate cannot answer for th
 ## Why the build rejects code that compiles in an IDE
 
 `allWarningsAsErrors` is on, so a warning fails the build. Published binaries target Java 11 and
-Kotlin language and API level 2.1, independent of the toolchain the build runs on, so a newer language
+Kotlin language and API level 2.2, independent of the toolchain the build runs on, so a newer language
 feature or standard-library API fails to compile even on a current JDK.
 
 ## Configuration

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,8 +37,9 @@ jobs:
           ./gradlew --no-daemon --stacktrace --continue \
             :buildSrc:ktlintCheck :buildSrc:detekt
 
-      # `build` runs `check` for every module (compile, ktlintCheck, detekt, the Android Lint
-      # Compose checks, test, checkKotlinAbi, and the jacocoTestCoverageVerification floors)
+      # `build` runs `check` for every module (compile, ktlintCheck, detekt including this
+      # project's own rules and the Compose rules, the Android Lint checks, test, checkKotlinAbi,
+      # and the jacocoTestCoverageVerification floors)
       # plus `assemble`. Driving it generically gates new modules automatically without
       # enumerating them. `checkKotlinAbi` validates the committed api/*.api dumps; it is named
       # explicitly alongside `build` so it stands out in the step's task list. `--continue`

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -26,6 +26,7 @@
             <option value="$PROJECT_DIR$/samples/widgets-gallery" />
             <option value="$PROJECT_DIR$/swing-ui" />
             <option value="$PROJECT_DIR$/swing-ui-animation" />
+            <option value="$PROJECT_DIR$/swing-ui-detekt" />
             <option value="$PROJECT_DIR$/swing-ui-test" />
           </set>
         </option>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,8 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="UnstableTypeUsedInSignature" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="TestOnlyProblems" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="MultiplatformPreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.20" />
+    <option name="version" value="2.4.20" />
   </component>
 </project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,12 @@ Piece by piece:
   ```bash
   ./gradlew updateKotlinAbi
   ```
-  Commit whichever of `swing-ui/api/swing-ui.api`, `swing-ui-test/api/swing-ui-test.api` and
-  `swing-ui-animation/api/swing-ui-animation.api` the change moved. A public-API change should be
-  intentional and reviewed.
+  Commit whichever of `swing-ui/api/swing-ui.api`, `swing-ui-detekt/api/swing-ui-detekt.api`,
+  `swing-ui-test/api/swing-ui-test.api` and `swing-ui-animation/api/swing-ui-animation.api` the change
+  moved. A public-API change should be intentional and reviewed.
 - **`:buildSrc:ktlintCheck` / `:buildSrc:detekt`** - formatting, lint and static analysis for the
   convention plugins. Run them whenever you touch anything under `buildSrc/`.
-- **`jacocoTestCoverageVerification`** - `swing-ui`, `swing-ui-test` and `swing-ui-animation` each
+- **`jacocoTestCoverageVerification`** - `swing-ui`, `swing-ui-detekt`, `swing-ui-test` and `swing-ui-animation` each
   enforce a line-coverage floor and a branch-coverage floor, measured per module against that
   module's own tests. A change that drops a ratio below its floor fails the build. Add tests for any
   new behavior you can reach through the test harness. The floors are held, not chased: if a branch is

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Full quality-gate command (what CI runs):
   components and layouts. See [`swing-ui/README.md`](swing-ui/README.md).
 - `swing-ui-animation` - the animation engine. See
   [`swing-ui-animation/README.md`](swing-ui-animation/README.md).
+- `swing-ui-detekt` - this library's own detekt rules. See
+  [`swing-ui-detekt/README.md`](swing-ui-detekt/README.md).
 - `swing-ui-test` - the test harness. See [`swing-ui-test/README.md`](swing-ui-test/README.md).
 - `samples/todo-app`, `samples/widgets-gallery` - runnable showcases.
 - `samples/docs` - the Kotlin snippets in this repository's Markdown, compiled by the build.
@@ -237,5 +239,5 @@ consume the libraries.
 Licensed under the Apache License, Version 2.0 - see [LICENSE](LICENSE).
 
 `swing-ui-animation` redistributes source code from the Android Open Source Project's Jetpack Compose
-`animation-core` under the same license; see that module's `META-INF/NOTICE` and the per-file headers
-for attribution.
+`animation-core` under the same license, and `swing-ui-detekt` one of that project's Android Lint
+checks; see each module's `META-INF/NOTICE` and the per-file headers for attribution.

--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ Full quality-gate command (what CI runs):
 
 ## Stability
 
-Pre-1.0: breaking API changes may land in any minor release. Kotlin 2.1 or newer is required to
+Pre-1.0: breaking API changes may land in any minor release. Kotlin 2.2 or newer is required to
 consume the libraries.
 
 ## License
 
 Licensed under the Apache License, Version 2.0 - see [LICENSE](LICENSE).
 
-`swing-ui-animation` additionally redistributes source code from the Android Open Source Project's
-Jetpack Compose `animation-core` under the same license; see that module's `META-INF/NOTICE` and the
-per-file headers for attribution.
+`swing-ui-animation` redistributes source code from the Android Open Source Project's Jetpack Compose
+`animation-core` under the same license; see that module's `META-INF/NOTICE` and the per-file headers
+for attribution.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,7 +37,10 @@ ktlint {
 
 detekt {
     buildUponDefaultConfig.set(true)
-    config.setFrom(rootDir.resolve("../config/detekt/detekt.yml"))
+    config.setFrom(
+        rootDir.resolve("../config/detekt/detekt.yml"),
+        rootDir.resolve("../config/detekt/rule-provider-overrides.yml"),
+    )
     ignoreFailures.set(false)
     parallel.set(true)
 }

--- a/buildSrc/src/main/kotlin/buildsrc/KotlinDefaults.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/KotlinDefaults.kt
@@ -1,0 +1,64 @@
+package buildsrc
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+private val publishedJvmTarget = JvmTarget.JVM_11
+
+/**
+ * The compiler and test settings every module in this repository is built under.
+ *
+ * A convention plugin cannot apply another from the same `buildSrc`, so a caller takes these settings
+ * by calling this rather than by applying a plugin.
+ */
+public fun Project.kotlinDefaults() {
+    extensions.configure<KotlinJvmProjectExtension>("kotlin") {
+        compilerOptions {
+            allWarningsAsErrors.set(true)
+            // JVM default methods without DefaultImpls bridges. Bridges only serve binaries compiled
+            // against a previously published DefaultImpls-bearing release - none exist before the first
+            // release - and removing them later would be binary-breaking, so bridge-less is the one-way
+            // door taken now. The vendored animation fork also requires this mode: upstream's
+            // @JvmDefaultWithCompatibility annotations (re-adding bridges per interface where androidx
+            // promises them) are only accepted by the compiler under it.
+            jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
+            // Published binaries and metadata stay consumable from Kotlin 2.2 toolchains, independent of
+            // the (newer) Kotlin the build itself runs on. 2.2 is the floor the compiler allows: it
+            // rejects 2.1 as deprecated, and this build turns that warning into an error.
+            languageVersion.set(KotlinVersion.KOTLIN_2_2)
+            apiVersion.set(KotlinVersion.KOTLIN_2_2)
+        }
+    }
+
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions.jvmTarget.set(publishedJvmTarget)
+    }
+
+    tasks.withType<JavaCompile>().configureEach {
+        options.release.set(publishedJvmTarget.target.toInt())
+    }
+
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+        // A test driving Swing can wait on the event dispatch thread for a state the thread it is waiting on
+        // will never reach. Failing such a test on a deadline reports the hang where it happened, instead of
+        // leaving the build to be killed with no result at all. This deadline sits above
+        // runComposeSwingTest's own 60s timeout so that gate's uncompleted-coroutine dump - the more
+        // informative failure - is what a test written against the harness actually sees; this one is the
+        // backstop for a real EDT deadlock, which blocks the thread rather than leaving a coroutine to dump.
+        // A case that legitimately needs longer carries its own `Timeout` annotation; the slowest case in
+        // the suite today takes about five seconds.
+        systemProperty("junit.jupiter.execution.timeout.testable.method.default", "90s")
+        // The deadline is only measured after a test method returns unless the method runs on a thread of its
+        // own, and a deadlocked method never returns. Running each on its own thread is what lets the deadline
+        // interrupt one.
+        systemProperty("junit.jupiter.execution.timeout.thread.mode.default", "SEPARATE_THREAD")
+    }
+}

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -20,10 +20,11 @@ kotlin {
         // @JvmDefaultWithCompatibility annotations (re-adding bridges per interface where androidx
         // promises them) are only accepted by the compiler under it.
         jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
-        // Published binaries and metadata stay consumable from Kotlin 2.1 toolchains, independent of
-        // the (newer) Kotlin the build itself runs on.
-        languageVersion.set(KotlinVersion.KOTLIN_2_1)
-        apiVersion.set(KotlinVersion.KOTLIN_2_1)
+        // Published binaries and metadata stay consumable from Kotlin 2.2 toolchains, independent of
+        // the (newer) Kotlin the build itself runs on. 2.2 is the floor the compiler allows: it
+        // rejects 2.1 as deprecated, and this build turns that warning into an error.
+        languageVersion.set(KotlinVersion.KOTLIN_2_2)
+        apiVersion.set(KotlinVersion.KOTLIN_2_2)
     }
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -1,60 +1,16 @@
 package buildsrc.convention
 
-import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import buildsrc.kotlinDefaults
 
 plugins {
     kotlin("jvm")
     kotlin("plugin.compose")
 }
 
-kotlin {
-    compilerOptions {
-        allWarningsAsErrors.set(true)
-        // JVM default methods without DefaultImpls bridges. Bridges only serve binaries compiled
-        // against a previously published DefaultImpls-bearing release - none exist before the first
-        // release - and removing them later would be binary-breaking, so bridge-less is the one-way
-        // door taken now. The vendored animation fork also requires this mode: upstream's
-        // @JvmDefaultWithCompatibility annotations (re-adding bridges per interface where androidx
-        // promises them) are only accepted by the compiler under it.
-        jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
-        // Published binaries and metadata stay consumable from Kotlin 2.2 toolchains, independent of
-        // the (newer) Kotlin the build itself runs on. 2.2 is the floor the compiler allows: it
-        // rejects 2.1 as deprecated, and this build turns that warning into an error.
-        languageVersion.set(KotlinVersion.KOTLIN_2_2)
-        apiVersion.set(KotlinVersion.KOTLIN_2_2)
-    }
-}
+kotlinDefaults()
 
 // The reports name which composables are skippable and which parameters are unstable.
 composeCompiler {
     reportsDestination.set(layout.buildDirectory.dir("compose-reports"))
     metricsDestination.set(layout.buildDirectory.dir("compose-metrics"))
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    options.release.set(11)
-}
-
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
-    // A test driving Swing can wait on the event dispatch thread for a state the thread it is waiting on
-    // will never reach. Failing such a test on a deadline reports the hang where it happened, instead of
-    // leaving the build to be killed with no result at all. This deadline sits above
-    // runComposeSwingTest's own 60s timeout so that gate's uncompleted-coroutine dump - the more
-    // informative failure - is what a test written against the harness actually sees; this one is the
-    // backstop for a real EDT deadlock, which blocks the thread rather than leaving a coroutine to dump.
-    // A case that legitimately needs longer carries its own `Timeout` annotation; the slowest case in
-    // the suite today takes about five seconds.
-    systemProperty("junit.jupiter.execution.timeout.testable.method.default", "90s")
-    // The deadline is only measured after a test method returns unless the method runs on a thread of its
-    // own, and a deadlocked method never returns. Running each on its own thread is what lets the deadline
-    // interrupt one.
-    systemProperty("junit.jupiter.execution.timeout.thread.mode.default", "SEPARATE_THREAD")
 }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-quality.gradle.kts
@@ -8,7 +8,7 @@ import org.gradle.kotlin.dsl.withType
 plugins {
     id("org.jlleitschuh.gradle.ktlint")
     id("dev.detekt")
-    // Standalone Android Lint runner (no AGP/Android SDK) hosting the Compose lint checks.
+    // Standalone Android Lint runner (no AGP/Android SDK) hosting the checks below.
     id("com.android.lint")
 }
 
@@ -44,16 +44,30 @@ tasks.named("check") {
     dependsOn(tasks.named("detektMain"), tasks.named("detektTest"))
 }
 
+// The module carrying this project's own detekt rules; it applies this convention too, and a module
+// cannot contribute its rules to itself.
+private val detektRuleSet = ":swing-ui-detekt"
+
+dependencies {
+    // This project's own rules, and the Compose rules that travel with them - the same artifact a
+    // consumer adds.
+    if (path != detektRuleSet) {
+        "detektPlugins"(project(detektRuleSet))
+    }
+}
+
 lint {
     warningsAsErrors = true
     lintConfig = rootProject.file("config/lint/lint.xml")
 }
 
 dependencies {
-    // Compose lint checks (slackhq/compose-lints) contributed to the Android Lint runtime.
+    // The Compose runtime publishes the checks for its own contracts as an artifact. They are the
+    // authors' checks, kept current with the runtime this project compiles against, so the runtime is
+    // held to them here rather than to a reimplementation of them.
     "lintChecks"(
         libs
-            .findLibrary("composeLintChecks")
-            .orElseThrow { IllegalStateException("Missing library 'composeLintChecks' in gradle/libs.versions.toml") },
+            .findLibrary("composeRuntimeLint")
+            .orElseThrow { IllegalStateException("Missing library 'composeRuntimeLint' in gradle/libs.versions.toml") },
     )
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -33,6 +33,68 @@ complexity:
     # precedented exemption as MagicNumber below.
     ignoreAnnotated: ["Composable"]
 
+# The Compose rules (io.nlopez.compose.rules), which arrive with `:swing-ui-detekt`, pointed at this
+# library's own types: SwingModifier is the chain the modifier rules are about, and every widget bottoms
+# out in one of two node primitives, so a call reaching either is what "emits content" means here. A
+# consumer configures the same block; swing-ui-detekt/README.md carries it.
+#
+# Several of these rules ask how an API is shaped or what a composition costs. A test fixture is
+# neither: it stands a composable up to drive one assertion and is gone.
+Compose:
+  ConditionHoist:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ContentEmitterReturningValues:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  LambdaParameterEventTrailing:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierClickableOrder:
+    # Reads androidx's Modifier.clickable, which has no counterpart here.
+    active: false
+  ModifierComposed:
+    # Reads androidx's Modifier.composed, which has no counterpart here.
+    active: false
+  ModifierMissing:
+    customModifiers: ['SwingModifier']
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierNaming:
+    customModifiers: ['SwingModifier']
+  ModifierNotUsedAtRoot:
+    customModifiers: ['SwingModifier']
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierReused:
+    customModifiers: ['SwingModifier']
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierWithoutDefault:
+    # No visibility threshold upstream, so it reports every private node helper a widget is built from.
+    # SwingModifierWithoutDefault checks the same thing where a caller outside the module sees it.
+    active: false
+  MultipleEmitters:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  CompositionLocalAllowlist:
+    excludes: ["**/src/test/**"]
+    # Layout constraints and the window a content composition has settled on are part of this
+    # framework's design, not an app's implicit dependency.
+    allowedCompositionLocals: ['LocalProvidableWindow']
+  LambdaParameterInRestartableEffect:
+    excludes: ["**/src/test/**"]
+  MutableStateAutoboxing:
+    excludes: ["**/src/test/**"]
+  ParameterNaming:
+    # Settlement is this library's own vocabulary, and the callback fires once the value has settled.
+    allowedLambdaParameterNames: ['onValueSettled']
+  StateParam:
+    excludes: ["**/src/test/**"]
+  VarsWithoutStateBacking:
+    excludes: ["**/src/test/**"]
+
+# Off by default in the artifact: these say nothing about what the library requires, and are declared
+# there only because no published ruleset provides them. This repository holds itself to them.
+compose-swing-internal:
+  PreferImportsOverFqn:
+    active: true
+  PublicDataClass:
+    active: true
+
 naming:
   FunctionNaming:
     # @Composable functions use PascalCase by Compose convention (e.g. Button, BorderPanel).

--- a/config/detekt/rule-provider-overrides.yml
+++ b/config/detekt/rule-provider-overrides.yml
@@ -1,0 +1,8 @@
+# Layered on top of detekt.yml where the project's own rules are not on detekt's classpath.
+#
+# A module cannot contribute its ruleset to itself, and buildSrc is an included build that cannot
+# depend on it; neither sees the Compose rules that arrive with it either. Config validation rejects a
+# section whose ruleset is absent, so those sections are excluded here rather than in detekt.yml, which
+# keeps them validated everywhere the rules do run.
+config:
+  excludes: ["Compose", "compose-swing", "compose-swing-internal"]

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Android Lint configuration for the Compose lint checks (slackhq/compose-lints).
+  Android Lint configuration.
 
-  This is a JVM library with no Android sources. The Compose conventions this library follows
-  (PascalCase @Composable naming, modifier-first / required-before-optional parameter ordering, and
-  the composition-structure correctness checks) are already enforced at compose-lints' own default
-  ERROR severity; only the entries below — which turn checks off — change behavior.
+  This is a JVM library with no Android sources. Lint runs here for the checks that hold code to the
+  contracts `androidx.annotation` states - `RestrictedApi`, `Range`, `VisibleForTests` - and for the
+  ones the Compose runtime publishes alongside itself. Every check runs at its own severity; only the
+  entries below, which turn checks off, change behavior.
 -->
 <lint>
     <!--
@@ -15,21 +15,4 @@
     -->
     <issue id="GradleDependency" severity="ignore" />
     <issue id="NewerVersionAvailable" severity="ignore" />
-
-    <!--
-      CompositionLocals are part of this framework's public design (layout constraints and shared
-      Swing context thread to children through them), so the app-oriented allowlist check is off.
-    -->
-    <issue id="ComposeCompositionLocalUsage" severity="ignore" />
-
-    <!--
-      The androidx Modifier-keyed checks key off a type this Swing runtime does not use; they cannot
-      recognize this library's own modifier type, so they are switched off rather than left to misfire.
-    -->
-    <issue id="ComposeModifierMissing" severity="ignore" />
-    <issue id="ComposeModifierWithoutDefault" severity="ignore" />
-    <issue id="ComposeModifierReused" severity="ignore" />
-
-    <!-- @Preview is an Android/desktop-tooling concept with no presence in this library. -->
-    <issue id="ComposePreviewPublic" severity="ignore" />
 </lint>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ detekt = "2.0.0-alpha.6"
 dokka = "2.2.0"
 jetbrainsAnnotations = "23.0.0"
 knit = "0.5.1"
-kotlin = "2.3.20"
+kotlin = "2.4.20"
 ktlint = "1.8.0"
 ktlint-gradle = "14.2.0"
 
@@ -25,7 +25,9 @@ androidxNavigation3Runtime = { module = "androidx.navigation3:navigation3-runtim
 androidxTracing = { module = "androidx.tracing:tracing", version.ref = "androidxTracing" }
 composeLintChecks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
 composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detekt" }
 detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+detekt-test = { module = "dev.detekt:detekt-test", version.ref = "detekt" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 dokka-versioning-plugin = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 jetbrainsAnnotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidxNavigation3 = "1.1.0"
 androidxTracing = "2.0.0"
 compose = "1.10.0"
 composeLintChecks = "1.6.0"
+composeRules = "0.6.6"
 coroutines = "1.9.0"
 detekt = "2.0.0-alpha.6"
 dokka = "2.2.0"
@@ -24,6 +25,7 @@ androidxLifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runti
 androidxNavigation3Runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidxNavigation3" }
 androidxTracing = { module = "androidx.tracing:tracing", version.ref = "androidxTracing" }
 composeLintChecks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
+composeRulesDetekt = { module = "io.nlopez.compose.rules:detekt", version.ref = "composeRules" }
 composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detekt" }
 detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ androidxLifecycle = "2.9.4"
 androidxNavigation3 = "1.1.0"
 androidxTracing = "2.0.0"
 compose = "1.10.0"
-composeLintChecks = "1.6.0"
 composeRules = "0.6.6"
 coroutines = "1.9.0"
 detekt = "2.0.0-alpha.6"
@@ -24,7 +23,7 @@ androidxCollection = { module = "androidx.collection:collection", version.ref = 
 androidxLifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidxNavigation3Runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidxNavigation3" }
 androidxTracing = { module = "androidx.tracing:tracing", version.ref = "androidxTracing" }
-composeLintChecks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
+composeRuntimeLint = { module = "androidx.compose.runtime:runtime-lint", version.ref = "compose" }
 composeRulesDetekt = { module = "io.nlopez.compose.rules:detekt", version.ref = "composeRules" }
 composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detekt" }

--- a/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/components/SpinnerCards.kt
+++ b/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/components/SpinnerCards.kt
@@ -2,6 +2,7 @@ package org.jetbrains.compose.swing.samples.widgets.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,7 +34,7 @@ internal fun ColumnScope.IntSpinnerCard() {
 @Composable
 internal fun ColumnScope.DoubleSpinnerCard() {
     ExampleCard("Spinner (Double)") {
-        var rate by remember { mutableStateOf(1.5) }
+        var rate by remember { mutableDoubleStateOf(1.5) }
         FlowPanel {
             Label("Rate:")
             Spinner(
@@ -110,7 +111,7 @@ internal fun ColumnScope.FormatSpinnerCard() {
 @Composable
 internal fun ColumnScope.EditorSpinnerCard() {
     ExampleCard("Spinner (composed editor)") {
-        var weight by remember { mutableStateOf(70.0) }
+        var weight by remember { mutableDoubleStateOf(70.0) }
         FlowPanel {
             Label("Weight:")
             // The editor composition is part of this one, so it reads the same state the card does and

--- a/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/runtime/AnimationSection.kt
+++ b/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/runtime/AnimationSection.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.compose.swing.samples.widgets.runtime
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -158,6 +159,7 @@ private fun PulsingDisc() {
 }
 
 @Composable
+@NonRestartableComposable
 private fun StaticDisc() {
     Disc(PULSE_MAX)
 }

--- a/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/runtime/CompositionLocalsSection.kt
+++ b/samples/widgets-gallery/src/main/kotlin/org/jetbrains/compose/swing/samples/widgets/runtime/CompositionLocalsSection.kt
@@ -19,6 +19,7 @@ import org.jetbrains.compose.swing.tooling.Preview
 import java.awt.Color
 
 // The accent color flowing down the composition; consumed several layers deep to style labels.
+@Suppress("CompositionLocalAllowlist")
 private val LocalAccent = staticCompositionLocalOf { Color.BLUE }
 
 // A staticCompositionLocalOf driving Swing components: a picker provides the chosen accent near the top,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include(":samples:todo-app")
 include(":samples:widgets-gallery")
 include(":swing-ui")
 include(":swing-ui-animation")
+include(":swing-ui-detekt")
 include(":swing-ui-test")
 
 rootProject.name = "compose-swing-ui"

--- a/swing-ui-animation/api/swing-ui-animation.api
+++ b/swing-ui-animation/api/swing-ui-animation.api
@@ -159,7 +159,7 @@ public final class org/jetbrains/compose/swing/animation/core/AnimationVector1D 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()F
 	public fun hashCode ()I
-	public synthetic fun newVector$swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
+	public synthetic fun newVector$org_jetbrains_compose_swing_swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -170,7 +170,7 @@ public final class org/jetbrains/compose/swing/animation/core/AnimationVector2D 
 	public final fun getV1 ()F
 	public final fun getV2 ()F
 	public fun hashCode ()I
-	public synthetic fun newVector$swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
+	public synthetic fun newVector$org_jetbrains_compose_swing_swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -182,7 +182,7 @@ public final class org/jetbrains/compose/swing/animation/core/AnimationVector3D 
 	public final fun getV2 ()F
 	public final fun getV3 ()F
 	public fun hashCode ()I
-	public synthetic fun newVector$swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
+	public synthetic fun newVector$org_jetbrains_compose_swing_swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -195,7 +195,7 @@ public final class org/jetbrains/compose/swing/animation/core/AnimationVector4D 
 	public final fun getV3 ()F
 	public final fun getV4 ()F
 	public fun hashCode ()I
-	public synthetic fun newVector$swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
+	public synthetic fun newVector$org_jetbrains_compose_swing_swing_ui_animation ()Lorg/jetbrains/compose/swing/animation/core/AnimationVector;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -208,6 +208,7 @@ public final class org/jetbrains/compose/swing/animation/core/AnimationVectorsKt
 
 public final class org/jetbrains/compose/swing/animation/core/ArcAnimationSpec : org/jetbrains/compose/swing/animation/core/DurationBasedAnimationSpec {
 	public static final field $stable I
+	public fun <init> ()V
 	public synthetic fun <init> (IIILorg/jetbrains/compose/swing/animation/core/Easing;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (IIILorg/jetbrains/compose/swing/animation/core/Easing;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -500,7 +501,7 @@ public final class org/jetbrains/compose/swing/animation/core/KeyframesSpec$Keyf
 	public fun at (Ljava/lang/Object;I)Lorg/jetbrains/compose/swing/animation/core/KeyframesSpec$KeyframeEntity;
 	public synthetic fun atFraction (Ljava/lang/Object;F)Lorg/jetbrains/compose/swing/animation/core/KeyframeBaseEntity;
 	public fun atFraction (Ljava/lang/Object;F)Lorg/jetbrains/compose/swing/animation/core/KeyframesSpec$KeyframeEntity;
-	public synthetic fun createEntityFor$swing_ui_animation (Ljava/lang/Object;)Lorg/jetbrains/compose/swing/animation/core/KeyframeBaseEntity;
+	public synthetic fun createEntityFor$org_jetbrains_compose_swing_swing_ui_animation (Ljava/lang/Object;)Lorg/jetbrains/compose/swing/animation/core/KeyframeBaseEntity;
 	public final fun using-0JVMp9Q (Lorg/jetbrains/compose/swing/animation/core/KeyframesSpec$KeyframeEntity;I)Lorg/jetbrains/compose/swing/animation/core/KeyframesSpec$KeyframeEntity;
 	public final fun with (Lorg/jetbrains/compose/swing/animation/core/KeyframesSpec$KeyframeEntity;Lorg/jetbrains/compose/swing/animation/core/Easing;)V
 }
@@ -529,7 +530,7 @@ public final class org/jetbrains/compose/swing/animation/core/KeyframesWithSplin
 public final class org/jetbrains/compose/swing/animation/core/KeyframesWithSplineSpec$KeyframesWithSplineSpecConfig : org/jetbrains/compose/swing/animation/core/KeyframesSpecBaseConfig {
 	public static final field $stable I
 	public fun <init> ()V
-	public synthetic fun createEntityFor$swing_ui_animation (Ljava/lang/Object;)Lorg/jetbrains/compose/swing/animation/core/KeyframeBaseEntity;
+	public synthetic fun createEntityFor$org_jetbrains_compose_swing_swing_ui_animation (Ljava/lang/Object;)Lorg/jetbrains/compose/swing/animation/core/KeyframeBaseEntity;
 }
 
 public abstract interface class org/jetbrains/compose/swing/animation/core/MotionDurationScale : kotlin/coroutines/CoroutineContext$Element {
@@ -555,7 +556,7 @@ public final class org/jetbrains/compose/swing/animation/core/MutableTransitionS
 	public fun getTargetState ()Ljava/lang/Object;
 	public final fun isIdle ()Z
 	public fun setTargetState (Ljava/lang/Object;)V
-	public synthetic fun setTargetState$swing_ui_animation (Ljava/lang/Object;)V
+	public synthetic fun setTargetState$org_jetbrains_compose_swing_swing_ui_animation (Ljava/lang/Object;)V
 }
 
 public final class org/jetbrains/compose/swing/animation/core/RepeatMode : java/lang/Enum {
@@ -706,7 +707,6 @@ public final class org/jetbrains/compose/swing/animation/core/TargetBasedAnimati
 
 public abstract class org/jetbrains/compose/swing/animation/core/Transition {
 	public static final field $stable I
-	public synthetic fun <init> (Lorg/jetbrains/compose/swing/animation/core/TransitionState;Lorg/jetbrains/compose/swing/animation/core/Transition;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lorg/jetbrains/compose/swing/animation/core/TransitionState;Lorg/jetbrains/compose/swing/animation/core/Transition;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAnimations ()Ljava/util/List;
 	public final fun getCurrentState ()Ljava/lang/Object;

--- a/swing-ui-animation/build.gradle.kts
+++ b/swing-ui-animation/build.gradle.kts
@@ -13,9 +13,7 @@ kotlin {
     explicitApi()
 
     @OptIn(ExperimentalAbiValidation::class)
-    abiValidation {
-        enabled.set(true)
-    }
+    abiValidation {}
 }
 
 dependencies {

--- a/swing-ui-detekt/README.md
+++ b/swing-ui-detekt/README.md
@@ -1,0 +1,83 @@
+# Module swing-ui-detekt
+
+This library's own detekt rules: the contracts its API carries that neither the compiler nor the
+formatter can hold.
+
+Adding this artifact also brings the Compose rules ([mrmans0n/compose-rules]) with it, so a consumer
+adds one line rather than two.
+
+| Rule | Reports |
+| --- | --- |
+| `SwingModifierWithoutDefault` | a composable a caller outside the module can reach whose chain parameter has no default, or defaults to something other than the empty chain |
+| `ComposableSwingModifierFactory` | a chain factory marked `@Composable`, which ties the value it builds to the composition that called it |
+| `SwingModifierFactoryReturnType` | a factory answering with an element type instead of `SwingModifier` |
+| `ModifierNodeInspectableProperties` | a modifier element that overrides neither `name` nor `declaredValues`, so it describes itself to a tool as a bare class name |
+| `SwingModifierFactoryExtensionFunction` | a factory that is not an extension on `SwingModifier` |
+| `SwingModifierUnreferencedReceiver` | a factory that builds a fresh chain and never reaches the one it was given |
+| `SwingModifierThen` | `then` handed a factory that takes its receiver implicitly, chaining it twice |
+| `UnheldColumnComparator` | a table column given a comparator built where the column is declared, which sorts the rows again on every pass |
+
+`ModifierNodeInspectableProperties` is ported from Android Lint's
+`ModifierNodeInspectablePropertiesDetector` and redistributed under the Apache License, Version 2.0,
+copyright The Android Open Source Project. See [`META-INF/NOTICE`](src/main/resources/META-INF/NOTICE)
+for the attribution and what the port changed.
+
+## Usage
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    id("dev.detekt")
+}
+
+dependencies {
+    implementation("org.jetbrains.compose.swing:swing-ui:<version>")
+    detektPlugins("org.jetbrains.compose.swing:swing-ui-detekt:<version>")
+}
+```
+
+The rules above are on as soon as the artifact is there. The Compose rules arrive with it, but detekt
+reads every plugin's bundled configuration as one document, so a section two plugins both declare
+would be a duplicate key - which means the Compose rules cannot be pointed at this library's types
+from here. Copy this into your own `detekt.yml`:
+
+```yaml
+Compose:
+  ModifierMissing:
+    customModifiers: ['SwingModifier']
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierNaming:
+    customModifiers: ['SwingModifier']
+  ModifierNotUsedAtRoot:
+    customModifiers: ['SwingModifier']
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierReused:
+    customModifiers: ['SwingModifier']
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ContentEmitterReturningValues:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  MultipleEmitters:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ConditionHoist:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  LambdaParameterEventTrailing:
+    contentEmitters: ['SwingNode', 'MenuNode']
+  ModifierClickableOrder:
+    active: false
+  ModifierComposed:
+    active: false
+  ModifierWithoutDefault:
+    active: false
+```
+
+`SwingModifier` is the chain those rules are about, and every widget this library declares bottoms out
+in `SwingNode` or `MenuNode`, so a call reaching either is what emits content. The last three read
+androidx types that have no counterpart here: `Modifier.clickable`, `Modifier.composed`, and a
+without-default check with no visibility threshold, which `SwingModifierWithoutDefault` replaces.
+
+## Related
+
+- [`../swing-ui/README.md`](../swing-ui/README.md) - the core library.
+- [`../docs/CUSTOM-COMPONENTS.md`](../docs/CUSTOM-COMPONENTS.md) - writing a component the rules apply to.
+
+[mrmans0n/compose-rules]: https://mrmans0n.github.io/compose-rules/

--- a/swing-ui-detekt/api/swing-ui-detekt.api
+++ b/swing-ui-detekt/api/swing-ui-detekt.api
@@ -1,0 +1,59 @@
+public final class org/jetbrains/compose/swing/detekt/ComposableSwingModifierFactory : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
+	public fun visitProperty (Lorg/jetbrains/kotlin/psi/KtProperty;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/ComposeSwingRuleSetProvider : dev/detekt/api/RuleSetProvider {
+	public fun <init> ()V
+	public fun getRuleSetId ()Ldev/detekt/api/RuleSetId;
+	public fun instance ()Ldev/detekt/api/RuleSet;
+}
+
+public final class org/jetbrains/compose/swing/detekt/ModifierNodeInspectableProperties : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitClassOrObject (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/SwingModifierFactoryExtensionFunction : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
+	public fun visitProperty (Lorg/jetbrains/kotlin/psi/KtProperty;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/SwingModifierFactoryReturnType : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
+	public fun visitProperty (Lorg/jetbrains/kotlin/psi/KtProperty;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/SwingModifierThen : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitBinaryExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpression;)V
+	public fun visitCallExpression (Lorg/jetbrains/kotlin/psi/KtCallExpression;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/SwingModifierUnreferencedReceiver : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
+	public fun visitProperty (Lorg/jetbrains/kotlin/psi/KtProperty;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/SwingModifierWithoutDefault : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
+}
+
+public final class org/jetbrains/compose/swing/detekt/UnheldColumnComparator : dev/detekt/api/Rule {
+	public fun <init> (Ldev/detekt/api/Config;)V
+	public fun getRuleName ()Ldev/detekt/api/RuleName;
+	public fun visitCallExpression (Lorg/jetbrains/kotlin/psi/KtCallExpression;)V
+}
+

--- a/swing-ui-detekt/build.gradle.kts
+++ b/swing-ui-detekt/build.gradle.kts
@@ -1,0 +1,62 @@
+import buildsrc.kotlinDefaults
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
+plugins {
+    kotlin("jvm")
+    id("buildsrc.convention.kotlin-quality")
+    id("buildsrc.convention.publishing")
+    id("buildsrc.convention.jacoco-coverage")
+}
+
+// Rules run inside detekt, not inside a composition, so nothing here is composed and the module takes
+// the shared settings directly rather than the `kotlin-jvm` convention, which adds the Compose plugin.
+kotlinDefaults()
+
+// A module cannot contribute its own ruleset to itself, so the sections detekt.yml configures for it
+// are not on this module's detekt classpath and would fail config validation.
+detekt {
+    config.setFrom(
+        rootProject.file("config/detekt/detekt.yml"),
+        rootProject.file("config/detekt/rule-provider-overrides.yml"),
+    )
+}
+
+kotlin {
+    explicitApi()
+
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {}
+}
+
+dependencies {
+    // detekt supplies its API to the rules it loads; carrying it at runtime would load a second copy.
+    compileOnly(libs.detekt.api)
+
+    // The Compose rules travel with this artifact: a consumer adding it to detektPlugins gets them on
+    // the same classpath, already pointed at this library's types by the config this jar carries.
+    api(libs.composeRulesDetekt)
+
+    // detekt-test asks for detekt-api's test-fixtures capability at runtime, but detekt 2.0.0-alpha
+    // publishes only the sources jar of those fixtures, so that variant cannot resolve. The fixtures
+    // back detekt-test's file-process-listener helpers alone, which nothing here touches.
+    testImplementation(libs.detekt.test) {
+        exclude(group = "dev.detekt", module = "detekt-api")
+    }
+    testImplementation(libs.detekt.api)
+    testImplementation(kotlin("test"))
+}
+
+// Leave headroom below current coverage; do not chase unreachable PSI branches with empty tests.
+jacocoCoverage {
+    lineMinimum.set("0.95".toBigDecimal())
+    branchMinimum.set("0.80".toBigDecimal())
+}
+
+publishing {
+    publications.named<MavenPublication>("maven") {
+        pom {
+            name.set("compose-swing-ui-detekt")
+            description.set("detekt rules for the compose-swing-ui API.")
+        }
+    }
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ComposableSwingModifierFactory.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ComposableSwingModifierFactory.kt
@@ -1,0 +1,52 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+
+/**
+ * Reports a `SwingModifier` factory marked `@Composable`.
+ *
+ * A chain is plain data. A factory that composes ties the value it builds to the composition that
+ * called it, so the chain can no longer be hoisted, held across passes, or built anywhere but inside a
+ * composable - and a caller who does hold it gets a value whose state belongs to a composition that has
+ * since left.
+ *
+ * A factory that needs something remembered takes it: `remember` it at the call site, or state it as a
+ * `remember*` function of its own that returns the value the plain factory then takes.
+ *
+ * Because this rule is PSI-only, it checks factories with an explicit `SwingModifier` return type and
+ * leaves inferred return types alone rather than guessing their semantic type.
+ */
+public class ComposableSwingModifierFactory(
+    config: Config,
+) : Rule(config, "A SwingModifier factory should be plain, not composable.") {
+    override val ruleName: RuleName = RuleName("ComposableSwingModifierFactory")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        reportIfComposableFactory(function)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+        if (property.isFactoryCandidate()) reportIfComposableFactory(property)
+    }
+
+    private fun reportIfComposableFactory(declaration: KtCallableDeclaration) {
+        if (!declaration.typeReference.declaresSwingModifier() || !declaration.isComposable()) return
+        report(
+            Finding(
+                entity = Entity.from(declaration),
+                message =
+                    "`${declaration.name}` builds a $SWING_MODIFIER and is `@Composable`, which ties the chain " +
+                        "to the composition that called it. Take what it needs to remember as a parameter.",
+            ),
+        )
+    }
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ComposeSwingInternalRuleSetProvider.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ComposeSwingInternalRuleSetProvider.kt
@@ -1,0 +1,29 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.RuleName
+import dev.detekt.api.RuleSet
+import dev.detekt.api.RuleSetId
+import dev.detekt.api.RuleSetProvider
+
+/**
+ * Rules this project holds itself to that say nothing about this library's API. They state things about
+ * Kotlin generally, and are declared here because no published ruleset provides them.
+ */
+internal class ComposeSwingInternalRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: RuleSetId = RuleSetId("compose-swing-internal")
+
+    override fun instance(): RuleSet =
+        RuleSet(
+            id = ruleSetId,
+            rules =
+                mapOf(
+                    RuleName("PreferImportsOverFqn") to { config: Config ->
+                        PreferImportsOverFqn(config)
+                    },
+                    RuleName("PublicDataClass") to { config: Config ->
+                        PublicDataClass(config)
+                    },
+                ),
+        )
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ComposeSwingRuleSetProvider.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ComposeSwingRuleSetProvider.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.RuleName
+import dev.detekt.api.RuleSet
+import dev.detekt.api.RuleSetId
+import dev.detekt.api.RuleSetProvider
+
+/**
+ * The rules this library contributes to detekt: how a `SwingModifier` is declared, taken and passed on,
+ * and what a declaration hands a component that adopts it by identity.
+ */
+public class ComposeSwingRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: RuleSetId = RuleSetId("compose-swing")
+
+    override fun instance(): RuleSet =
+        RuleSet(
+            id = ruleSetId,
+            rules =
+                mapOf(
+                    RuleName("ComposableSwingModifierFactory") to { config: Config ->
+                        ComposableSwingModifierFactory(config)
+                    },
+                    RuleName("ModifierNodeInspectableProperties") to { config: Config ->
+                        ModifierNodeInspectableProperties(config)
+                    },
+                    RuleName("SwingModifierFactoryExtensionFunction") to { config: Config ->
+                        SwingModifierFactoryExtensionFunction(config)
+                    },
+                    RuleName("SwingModifierFactoryReturnType") to { config: Config ->
+                        SwingModifierFactoryReturnType(config)
+                    },
+                    RuleName("SwingModifierThen") to { config: Config ->
+                        SwingModifierThen(config)
+                    },
+                    RuleName("SwingModifierUnreferencedReceiver") to { config: Config ->
+                        SwingModifierUnreferencedReceiver(config)
+                    },
+                    RuleName("SwingModifierWithoutDefault") to { config: Config ->
+                        SwingModifierWithoutDefault(config)
+                    },
+                    RuleName("UnheldColumnComparator") to { config: Config ->
+                        UnheldColumnComparator(config)
+                    },
+                ),
+        )
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ModifierNodeInspectableProperties.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/ModifierNodeInspectableProperties.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Ported from androidx's ModifierNodeInspectablePropertiesDetector (frameworks/support/compose/ui/
+// ui-lint/src/main/java/androidx/compose/ui/lint/ModifierNodeInspectablePropertiesDetector.kt), an
+// Android Lint UastScanner, to a detekt Rule. The counterpart of upstream's `ModifierNodeElement` and
+// its `InspectorInfo.inspectableProperties()` is `SwingModifier.InspectableElement` and its two open
+// members, `name` and `declaredValues`, so the following are substituted or dropped:
+//  - The self-description an element may declare is two properties rather than one function, so an
+//    element overriding either one is satisfied, and only one overriding neither is reported.
+//    Upstream's two "almost overrides it" cases - a wrong parameter list, a missing receiver - become
+//    the one case a property has: a member of that name that is not an override of the interface's,
+//    which is any declaration outside the class's own body or primary constructor.
+//  - Upstream matches its supertype by resolved fully qualified name and reaches every subclass however
+//    deep. This rule requires a declaration's direct supertype to be qualified by the library
+//    `SwingModifier`, including an import alias for it. An unqualified `InspectableElement` supertype,
+//    a type alias or an intermediate type is not seen; what the rule cannot identify safely, it skips.
+//  - An element built from nothing is skipped, where upstream reports every element. Both defaults are
+//    correct for it: there is no value to declare, and the class name is the whole of what it is. Only an
+//    element carrying state a reader declared - a constructor parameter that is not a callback - is
+//    reported.
+//  - Interfaces and abstract classes are skipped, where upstream reports them. Neither can be an entry
+//    on a modifier, and the concrete classes below them carry their own overrides.
+
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.psiUtil.unwrapNullability
+
+/**
+ * Reports a modifier element that describes itself to nothing: one implementing
+ * `SwingModifier.InspectableElement` that overrides neither `name` nor `declaredValues`.
+ *
+ * Both members carry a default, so such an element compiles and a tool showing the modifier a component
+ * carries reads the class name off it and no declared values at all. Overriding one of them says what the
+ * entry is called, or what it declares, in the one place a tool can read it.
+ *
+ * An element carrying no state a reader declared is passed over: its class name is the whole of what it
+ * is, and it has no values to name. So is an interface or an abstract class - neither is an entry on a
+ * modifier, and the classes below it declare their own.
+ *
+ * Only direct supertypes qualified by the library `SwingModifier` or its import alias are matched. This
+ * avoids treating an unrelated type with the same simple name as this library's element contract.
+ */
+public class ModifierNodeInspectableProperties(
+    config: Config,
+) : Rule(config, "A modifier element should describe itself with a name or the values it declares.") {
+    override val ruleName: RuleName = RuleName("ModifierNodeInspectableProperties")
+
+    private companion object {
+        val SELF_DESCRIPTION: Set<String> = setOf("name", "declaredValues")
+
+        /** Supertypes that directly provide the inspectable element contract. */
+        val INSPECTABLE_SUPERTYPES: Set<String> = setOf("InspectableElement", "NodeElement")
+    }
+
+    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+        super.visitClassOrObject(classOrObject)
+        if (!classOrObject.isAnInspectableElement() || !classOrObject.carriesDeclaredState()) return
+        if (classOrObject.describesItself()) return
+        report(
+            Finding(
+                entity = Entity.atName(classOrObject),
+                message =
+                    "`${classOrObject.name ?: "The element"}` overrides neither `name` nor " +
+                        "`declaredValues`, so a tool showing the modifier a component carries reads the " +
+                        "class name off it and none of what it declares. Override `name` where the class " +
+                        "name is not what the entry is called, and `declaredValues` with what it carries.",
+            ),
+        )
+    }
+
+    private fun KtClassOrObject.isAnInspectableElement(): Boolean {
+        val declaresAnEntry =
+            when (this) {
+                is KtClass -> !isInterface() && !hasModifier(KtTokens.ABSTRACT_KEYWORD)
+                else -> true
+            }
+        return declaresAnEntry &&
+            superTypeListEntries.any {
+                val type = it.typeReference?.typeElement as? KtUserType
+                type?.referencedName in INSPECTABLE_SUPERTYPES && type?.isDirectlyQualifiedBySwingModifier() == true
+            }
+    }
+
+    private fun KtUserType.isDirectlyQualifiedBySwingModifier(): Boolean =
+        qualifier?.declaresLibrarySwingModifier() == true
+
+    /**
+     * Whether [this] carries state a reader declared: a primary constructor parameter that is not a callback.
+     * A lambda renders as its own class, so it is nothing to show and nothing to hold an element to.
+     */
+    private fun KtClassOrObject.carriesDeclaredState(): Boolean {
+        val parameters = primaryConstructor?.valueParameters ?: return false
+        return parameters.any { it.typeReference?.typeElement?.unwrapNullability() !is KtFunctionType }
+    }
+
+    /**
+     * Whether [this] overrides either member of the interface, in its own body or as a property of its primary
+     * constructor - the form a shared element seam takes, where the name arrives as an argument.
+     *
+     * Only the declarations the class itself makes count: a nested class or a companion declaring a `name` of
+     * its own leaves the element's still standing at the default.
+     */
+    private fun KtClassOrObject.describesItself(): Boolean =
+        declarations.filterIsInstance<KtProperty>().any { it.overridesSelfDescription() } ||
+            primaryConstructor?.valueParameters?.any { it.hasValOrVar() && it.overridesSelfDescription() } == true
+
+    private fun KtNamedDeclaration.overridesSelfDescription(): Boolean =
+        hasModifier(KtTokens.OVERRIDE_KEYWORD) && name in SELF_DESCRIPTION
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/PreferImportsOverFqn.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/PreferImportsOverFqn.kt
@@ -1,0 +1,76 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.psiUtil.unwrapNullability
+
+/**
+ * Flags fully qualified type references that should be expressed with imports.
+ *
+ * Expression chains are deliberately ignored: PSI alone cannot distinguish a package root from a
+ * value receiver, so reporting them would make valid member access fail the rule.
+ */
+internal class PreferImportsOverFqn(
+    config: Config,
+) : Rule(config, "Direct fully-qualified names should be replaced with imports.") {
+    override val ruleName: RuleName = RuleName("PreferImportsOverFqn")
+
+    override fun visitTypeReference(typeReference: KtTypeReference) {
+        super.visitTypeReference(typeReference)
+        val userType = typeReference.typeElement?.unwrapNullability() as? KtUserType ?: return
+        val candidate = normalizeTypeCandidate(userType.text)
+        if (!looksLikeDirectFqnType(candidate)) {
+            return
+        }
+        reportViolation(entity = Entity.from(userType), text = candidate)
+    }
+
+    private fun reportViolation(
+        entity: Entity,
+        text: String,
+    ) {
+        report(
+            Finding(
+                entity = entity,
+                message = "Use import instead of direct FQN: $text",
+            ),
+        )
+    }
+
+    private fun normalizeTypeCandidate(text: String): String =
+        text
+            .substringBefore('<')
+            .trim()
+
+    private fun looksLikeDirectFqnType(text: String): Boolean {
+        val segments = text.split('.')
+        val packagePrefixLength = lowercasePrefixLength(segments)
+        val hasEnoughSegments = segments.size >= MIN_SEGMENTS_FOR_TYPE_FQN
+        val hasNoBlankSegments = segments.none(String::isBlank)
+        val typeSegments = segments.drop(packagePrefixLength)
+        val hasPackagePrefix = packagePrefixLength > 0
+        val hasTypeSegments = typeSegments.isNotEmpty()
+        val typeSegmentsStartWithUppercase =
+            typeSegments.all { it.firstOrNull()?.isUpperCase() == true }
+        return hasEnoughSegments &&
+            hasNoBlankSegments &&
+            hasPackagePrefix &&
+            hasTypeSegments &&
+            typeSegmentsStartWithUppercase
+    }
+
+    private fun looksLikePackageToken(token: String): Boolean =
+        token.firstOrNull()?.isLowerCase() == true &&
+            token.all { char -> char == '_' || char.isLowerCase() || char.isDigit() }
+
+    private fun lowercasePrefixLength(segments: List<String>): Int = segments.takeWhile(::looksLikePackageToken).size
+
+    private companion object {
+        private const val MIN_SEGMENTS_FOR_TYPE_FQN = 2
+    }
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/PublicDataClass.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/PublicDataClass.kt
@@ -1,0 +1,60 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+
+/**
+ * Reports a `data class` that a consumer can see.
+ *
+ * The compiler generates `copy` and `componentN` from the primary constructor, and both are part of the
+ * binary a consumer links against. A parameter added later changes their signatures, so code compiled
+ * against the previous ones stops linking - a break that no source change to the class can avoid. A
+ * regular class publishes the members it chooses and can gain a constructor parameter without touching
+ * any of them.
+ *
+ * Explicit API mode requires a visibility keyword; it says nothing about `data`, so a public data class
+ * compiles cleanly under it.
+ *
+ * A `data object` is left alone: it generates `equals`, `hashCode` and `toString` and no constructor-shaped
+ * members, so there is nothing for a later parameter to change.
+ *
+ * A class is taken to be out of reach when it, or anything it is declared inside, is `private` or
+ * `internal`. `protected` is reported, being the surface a subclass outside the module compiles against.
+ */
+internal class PublicDataClass(
+    config: Config,
+) : Rule(config, "A data class in the public API cannot gain a constructor parameter without breaking callers.") {
+    override val ruleName: RuleName = RuleName("PublicDataClass")
+
+    override fun visitClass(klass: KtClass) {
+        super.visitClass(klass)
+        if (!klass.isData() || klass.isLocal || !klass.isReachableFromOutside()) return
+        report(
+            Finding(
+                entity = Entity.from(klass.nameIdentifier ?: klass),
+                message = MESSAGE,
+            ),
+        )
+    }
+}
+
+private const val MESSAGE: String =
+    "This data class is part of the published API, so its generated `copy` and `componentN` are too. " +
+        "Adding a constructor parameter later changes their signatures and breaks a caller compiled " +
+        "against the previous ones. Declare a regular class carrying the members it means to publish."
+
+/**
+ * Whether a consumer outside this module can name [this]: neither it nor any class or object it is
+ * declared inside is `private` or `internal`. A companion is a container like any other, so a data class
+ * inside the companion of a public class is reachable.
+ */
+internal fun KtClassOrObject.isReachableFromOutside(): Boolean =
+    generateSequence(this) { it.getStrictParentOfType<KtClassOrObject>() }
+        .none { it.hasModifier(KtTokens.PRIVATE_KEYWORD) || it.hasModifier(KtTokens.INTERNAL_KEYWORD) }

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierChaining.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierChaining.kt
@@ -1,0 +1,264 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.parents
+
+/**
+ * Reports a `SwingModifier` factory whose body never reaches the chain it was given.
+ *
+ * A factory extension is handed the receiver so a caller's own chain rides through it. A body that
+ * restarts the chain from `SwingModifier` itself, rather than from the receiver, returns a chain built
+ * from nothing and drops everything the caller had declared.
+ *
+ * Nothing short of resolving types tells a call that takes the receiver implicitly apart from a plain
+ * function call, so a body that delegates that way - `listener(...)`, `binding(...)`, `property(...)`,
+ * which is how most factories in this library are written - is passed over. Only a body whose answer is
+ * a chain rooted at `SwingModifier` itself, taking the receiver in nowhere along it, is reported: that
+ * is the one shape a fresh chain and a dropped receiver can be told apart in without resolving
+ * anything.
+ */
+public class SwingModifierUnreferencedReceiver(
+    config: Config,
+) : Rule(config, "A SwingModifier factory should return a chain that includes the receiver it was given.") {
+    override val ruleName: RuleName = RuleName("SwingModifierUnreferencedReceiver")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        reportIfChainIsRestartedFromScratch(function, function.bodyExpression)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+        if (property.isFactoryCandidate()) {
+            reportIfChainIsRestartedFromScratch(property, property.getter?.bodyExpression)
+        }
+    }
+
+    private fun reportIfChainIsRestartedFromScratch(
+        declaration: KtCallableDeclaration,
+        body: KtExpression?,
+    ) {
+        val restartsTheChain =
+            declaration.receiverTypeReference.declaresSwingModifier() &&
+                declaration.returnsAChain() &&
+                body?.restartsTheChainFromScratch(declaration) == true
+        if (!restartsTheChain) return
+        report(
+            Finding(
+                entity = Entity.from(declaration),
+                message =
+                    "The `${declaration.name}` factory returns a chain built from `$SWING_MODIFIER` " +
+                        "itself and never reaches the receiver it was given. Return a chain that " +
+                        "includes the receiver, `this.then(MyElement)`, or a call to another factory " +
+                        "on it, `myElement()`.",
+            ),
+        )
+    }
+
+    /** Whether this body demonstrably returns a fresh chain without its receiver. */
+    private fun KtExpression.restartsTheChainFromScratch(declaration: KtCallableDeclaration): Boolean =
+        returnedExpressions().any {
+            (it.chainRoot() as? KtNameReferenceExpression)?.isLibrarySwingModifierValue() == true &&
+                !it.reachesTheReceiver(declaration)
+        }
+
+    /** A body's own unlabeled `return`s and the values its expression body can answer with. */
+    private fun KtExpression.returnedExpressions(): List<KtExpression> =
+        if (this is KtBlockExpression) {
+            collectDescendantsOfType<KtReturnExpression> {
+                it.getTargetLabel() == null && it.belongsTo(this)
+            }.mapNotNull { it.returnedExpression }.flatMap { it.terminalResults() }
+        } else {
+            terminalResults()
+        }
+
+    /** The values terminal Kotlin expression forms can answer with. */
+    private fun KtExpression?.terminalResults(): List<KtExpression> =
+        when (this) {
+            is KtBlockExpression -> {
+                statements.lastOrNull().terminalResults()
+            }
+
+            is KtIfExpression -> {
+                getElse()?.let { listOfNotNull(then, it).flatMap { branch -> branch.terminalResults() } }.orEmpty()
+            }
+
+            is KtWhenExpression -> {
+                entries.mapNotNull { it.expression }.flatMap { it.terminalResults() }
+            }
+
+            is KtTryExpression -> {
+                (listOf(tryBlock) + catchClauses.mapNotNull { it.catchBody }).flatMap { it.terminalResults() }
+            }
+
+            null -> {
+                emptyList()
+            }
+
+            else -> {
+                listOf(this)
+            }
+        }
+
+    /** A return belongs to this body when no nested callable or accessor owns it before the body does. */
+    private fun KtReturnExpression.belongsTo(body: KtBlockExpression): Boolean =
+        parents.takeWhile { it !== body }.none {
+            it is KtNamedFunction || it is KtPropertyAccessor
+        }
+
+    private tailrec fun KtExpression.chainRoot(): KtExpression {
+        val left =
+            when (this) {
+                is KtDotQualifiedExpression -> receiverExpression
+                is KtBinaryExpression -> left.takeIf { operationReference.getReferencedName() == "then" }
+                is KtParenthesizedExpression -> expression
+                else -> null
+            }
+        return left?.chainRoot() ?: this
+    }
+
+    /** Whether this chain contains the factory receiver, including an explicitly labeled one. */
+    private fun KtExpression.reachesTheReceiver(declaration: KtCallableDeclaration): Boolean =
+        anyDescendantOfType<KtThisExpression> { self ->
+            self.getLabelName() == declaration.name ||
+                (
+                    self.getTargetLabel() == null &&
+                        self.parents.takeWhile { it !== this }.none { it is KtLambdaExpression }
+                )
+        }
+
+    /** Whether this declaration answers with the chain. */
+    private fun KtCallableDeclaration.returnsAChain(): Boolean = typeReference.declaresSwingModifier()
+}
+
+/**
+ * Reports `then` handed a factory call that takes its receiver implicitly, chaining the receiver twice.
+ *
+ * `then` takes an already-built chain as its argument. A factory called inside it without an explicit
+ * receiver chains onto the caller's own receiver a second time: `this.then(factory())` expands to
+ * `this.then(this.then(Element))`, and everything the caller had declared before that point appears twice
+ * on the resulting chain.
+ *
+ * Nothing short of resolving types tells such a call apart from a bare function call that carries no
+ * receiver at all - the two read alike. Only a call whose callee is declared, elsewhere in the same file,
+ * as an extension on `SwingModifier` is reported here.
+ */
+public class SwingModifierThen(
+    config: Config,
+) : Rule(config, "then given a factory call that takes its receiver implicitly chains the receiver twice.") {
+    override val ruleName: RuleName = RuleName("SwingModifierThen")
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        reportChainedTwice(expression.argumentChainedTwiceByThen())
+    }
+
+    override fun visitBinaryExpression(expression: KtBinaryExpression) {
+        super.visitBinaryExpression(expression)
+        reportChainedTwice(expression.argumentChainedTwiceByThen())
+    }
+
+    private fun reportChainedTwice(chainedTwice: KtCallExpression?) {
+        if (chainedTwice == null) return
+        report(
+            Finding(
+                entity = Entity.from(chainedTwice),
+                message =
+                    "Calling a `$SWING_MODIFIER` factory with an implicit receiver inside `then` chains " +
+                        "the receiver twice. Chain the factory onto the receiver directly, " +
+                        "`this.${chainedTwice.text}`, or give it the empty chain, " +
+                        "`this.then($SWING_MODIFIER.${chainedTwice.text})`.",
+            ),
+        )
+    }
+
+    /** The bare factory argument when this `then` call demonstrably targets the chain. */
+    private fun KtCallExpression.argumentChainedTwiceByThen(): KtCallExpression? =
+        valueArguments
+            .singleOrNull()
+            ?.getArgumentExpression()
+            ?.takeIf {
+                val qualifier = parent as? KtQualifiedExpression
+                val hasKnownReceiver =
+                    (qualifier == null && hasImplicitSwingModifierReceiver() && !isShadowedByLocalCallable("then")) ||
+                        qualifier?.let { qualified ->
+                            qualified.selectorExpression === this &&
+                                qualified.receiverExpression.hasKnownSwingModifierReceiver()
+                        } == true
+                calleeExpression?.text == "then" && hasKnownReceiver
+            }?.let { it as? KtCallExpression }
+            ?.takeIf { it.calleeDeclaresSwingModifierReceiver() }
+
+    private fun KtCallExpression.hasImplicitSwingModifierReceiver(): Boolean =
+        parents
+            .takeWhile { it !is KtLambdaExpression }
+            .filterIsInstance<KtCallableDeclaration>()
+            .firstOrNull { it is KtNamedFunction || it is KtProperty }
+            ?.receiverTypeReference
+            .declaresSwingModifier()
+
+    private fun KtCallExpression.isShadowedByLocalCallable(name: String): Boolean =
+        parents.filterIsInstance<KtBlockExpression>().any { block ->
+            block.statements.any {
+                (it is KtNamedFunction && it.isLocal && it.name == name) ||
+                    (it is KtProperty && it.isLocal && it.name == name && it.textOffset < textOffset)
+            }
+        }
+
+    private fun KtBinaryExpression.argumentChainedTwiceByThen(): KtCallExpression? =
+        (right as? KtCallExpression)
+            ?.takeIf { operationReference.getReferencedName() == "then" }
+            ?.takeIf { left?.hasKnownSwingModifierReceiver() == true }
+            ?.takeIf { it.calleeDeclaresSwingModifierReceiver() }
+
+    private fun KtExpression.hasKnownSwingModifierReceiver(): Boolean =
+        (this as? KtThisExpression)?.let { self ->
+            val label = self.getLabelName()
+            val scope = if (label == null) self.parents.takeWhile { it !is KtLambdaExpression } else self.parents
+            scope
+                .filterIsInstance<KtCallableDeclaration>()
+                .firstOrNull {
+                    (it is KtNamedFunction || it is KtProperty) && (label == null || it.name == label)
+                }?.receiverTypeReference
+                .declaresSwingModifier()
+        } == true
+
+    private fun KtCallExpression.calleeDeclaresSwingModifierReceiver(): Boolean {
+        val name = calleeExpression?.text
+        val file = containingFile as? KtFile
+        val shadowsTopLevelFactory = name != null && isShadowedByLocalCallable(name)
+        if (name == null || shadowsTopLevelFactory) return false
+        val candidates =
+            file
+                ?.declarations
+                ?.filterIsInstance<KtNamedFunction>()
+                ?.filter { it.name == name }
+                .orEmpty()
+        return candidates.singleOrNull()?.receiverTypeReference.declaresSwingModifier()
+    }
+}

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierFactoryShape.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierFactoryShape.kt
@@ -1,0 +1,220 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.parents
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.psi.psiUtil.unwrapNullability
+
+/**
+ * Reports a `SwingModifier` factory that returns the element it builds instead of the chain.
+ *
+ * A caller reads one type all the way through a chain of factory calls. A factory that narrows its
+ * return type to the element it builds breaks that chain and makes the element part of the API.
+ *
+ * Only a declaration already declared as an extension on the chain is a factory candidate here:
+ * nothing short of resolving types tells a plain declaration's return type apart from any other type
+ * with the same name, so a declaration is checked only once its receiver already marks it as one.
+ */
+public class SwingModifierFactoryReturnType(
+    config: Config,
+) : Rule(config, "A SwingModifier factory should return SwingModifier, not the element type it builds.") {
+    override val ruleName: RuleName = RuleName("SwingModifierFactoryReturnType")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        reportIfReturnTypeIsNotTheChain(function)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+        if (property.isFactoryCandidate()) reportIfReturnTypeIsNotTheChain(property)
+    }
+
+    private fun reportIfReturnTypeIsNotTheChain(declaration: KtCallableDeclaration) {
+        if (!declaration.receiverTypeReference.declaresSwingModifier() || !declaration.isReachableFromOutside()) {
+            return
+        }
+        val returnType = declaration.typeReference
+        if (returnType == null || returnType.declaresSwingModifier()) return
+        report(
+            Finding(
+                entity = Entity.from(returnType),
+                message =
+                    "The `${declaration.name}` factory returns `${returnType.text}`. Return `$SWING_MODIFIER` " +
+                        "so a caller can keep chaining onto it.",
+            ),
+        )
+    }
+}
+
+/**
+ * Reports a `SwingModifier` factory that is not declared as an extension on the chain.
+ *
+ * A factory is declared as an extension on `SwingModifier` so that calls chain fluently. A factory that
+ * is not an extension has to be joined onto the chain by hand with `then`.
+ *
+ * Only a declaration already declared to return the chain itself is a factory candidate here: nothing
+ * short of resolving types tells a plain declaration's return type apart from any other type with the
+ * same name, so a declaration is checked only once its own return type already marks it as one.
+ */
+public class SwingModifierFactoryExtensionFunction(
+    config: Config,
+) : Rule(config, "A SwingModifier factory should be declared as an extension on SwingModifier.") {
+    override val ruleName: RuleName = RuleName("SwingModifierFactoryExtensionFunction")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        reportIfNotAnExtension(function, declaredAs = "fun $SWING_MODIFIER.${function.name}(...)")
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+        if (property.isFactoryCandidate()) {
+            reportIfNotAnExtension(property, declaredAs = "val $SWING_MODIFIER.${property.name} get() = ...")
+        }
+    }
+
+    private fun reportIfNotAnExtension(
+        declaration: KtCallableDeclaration,
+        declaredAs: String,
+    ) {
+        val returnType = declaration.typeReference
+        if (returnType == null || !returnType.declaresSwingModifier() || !declaration.isReachableFromOutside()) {
+            return
+        }
+        if (declaration.receiverTypeReference.declaresSwingModifier() || declaration.isMemberOfTheChain()) return
+        report(
+            Finding(
+                entity = Entity.from(declaration),
+                message =
+                    "The `${declaration.name}` factory is not an extension on `$SWING_MODIFIER`. Declare it as " +
+                        "`$declaredAs` so calls chain fluently.",
+            ),
+        )
+    }
+}
+
+/**
+ * Whether [this] names the library chain in a form this PSI-only rule can identify reliably.
+ *
+ * An arbitrary qualified name ending in `SwingModifier` is not enough: a consumer can define
+ * `Other.SwingModifier`, and resolving that name would make the rule depend on a compiler classpath.
+ * Keep the accepted forms to the imported/simple name and the library's exact FQN.
+ */
+internal fun KtTypeReference?.declaresSwingModifier(): Boolean =
+    (this?.typeElement?.unwrapNullability() as? KtUserType)?.let { type ->
+        type.declaresLibrarySwingModifier()
+    } == true
+
+internal const val SWING_MODIFIER_PACKAGE: String = "org.jetbrains.compose.swing.modifier"
+
+internal const val SWING_MODIFIER_FQN: String = "$SWING_MODIFIER_PACKAGE.$SWING_MODIFIER"
+
+internal fun KtUserType.declaresLibrarySwingModifier(): Boolean =
+    qualifier?.let { it.text == SWING_MODIFIER_PACKAGE && referencedName == SWING_MODIFIER }
+        ?: (containingFile as? KtFile)?.let { file ->
+            !isShadowedLexically(referencedName) &&
+                !file.declaresTypeName(referencedName) &&
+                file.resolvesImportedName(referencedName, SWING_MODIFIER_FQN)
+        }
+        ?: false
+
+private fun KtUserType.isShadowedLexically(name: String?): Boolean =
+    parents.filterIsInstance<KtClassOrObject>().any { owner ->
+        owner.name == name || owner.declarations.any { it.isTypeNamed(name) }
+    } ||
+        parents.filterIsInstance<KtTypeParameterListOwner>().any { owner ->
+            owner.typeParameters.any { it.name == name }
+        }
+
+private fun KtFile.declaresTypeName(name: String?): Boolean = declarations.any { it.isTypeNamed(name) }
+
+private fun KtDeclaration.isTypeNamed(name: String?): Boolean =
+    when (this) {
+        is KtClassOrObject -> this.name == name
+        is KtTypeAlias -> this.name == name
+        else -> false
+    }
+
+internal fun KtFile.resolvesImportedName(
+    referencedName: String?,
+    fullyQualifiedName: String,
+): Boolean {
+    val exactImports = importDirectives.filter { !it.isAllUnder && it.importedName() == referencedName }
+    val packageName = fullyQualifiedName.substringBeforeLast('.')
+    val simpleName = fullyQualifiedName.substringAfterLast('.')
+    return when {
+        exactImports.isNotEmpty() -> {
+            exactImports.singleOrNull()?.importPath?.pathStr == fullyQualifiedName
+        }
+
+        referencedName != simpleName -> {
+            false
+        }
+
+        packageFqName.asString() == packageName -> {
+            true
+        }
+
+        else -> {
+            val wildcardImports = importDirectives.filter(KtImportDirective::isAllUnder)
+            wildcardImports
+                .singleOrNull()
+                ?.importPath
+                ?.pathStr
+                ?.removeSuffix(".*") == packageName
+        }
+    }
+}
+
+internal fun KtImportDirective.importedName(): String? = aliasName ?: importPath?.pathStr?.substringAfterLast('.')
+
+internal fun KtNameReferenceExpression.isLibrarySwingModifierValue(): Boolean =
+    !isShadowedByValue() && containingKtFile.resolvesImportedName(getReferencedName(), SWING_MODIFIER_FQN)
+
+private fun KtNameReferenceExpression.isShadowedByValue(): Boolean {
+    val name = getReferencedName()
+    val hasParameter =
+        parents.filterIsInstance<KtNamedFunction>().firstOrNull()?.valueParameters?.any {
+            it.name == name && it.startOffset < startOffset
+        } == true
+    val hasLocal =
+        parents.filterIsInstance<KtBlockExpression>().any { block ->
+            block.statements.filterIsInstance<KtProperty>().any {
+                it.name == name && it.startOffset < startOffset
+            }
+        }
+    val hasTopLevel = containingKtFile.declarations.filterIsInstance<KtProperty>().any { it.name == name }
+    return hasParameter || hasLocal || hasTopLevel
+}
+
+/**
+ * Whether [this] is declared inside `SwingModifier` itself, where it is already on the chain and an
+ * extension receiver would say the same thing twice.
+ */
+internal fun KtCallableDeclaration.isMemberOfTheChain(): Boolean =
+    parents.filterIsInstance<KtClassOrObject>().any { it.name == SWING_MODIFIER } || isImplementingSomething()
+
+/**
+ * Whether [this] property is a factory candidate: a top-level `val` with a getter, the shape a property
+ * takes when it acts as a `SwingModifier` factory.
+ */
+internal fun KtProperty.isFactoryCandidate(): Boolean = containingClassOrObject == null && !isVar && getter != null

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierWithoutDefault.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierWithoutDefault.kt
@@ -1,0 +1,126 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.psiUtil.parents
+
+/**
+ * Reports a composable whose `SwingModifier` parameter does not default to the empty chain.
+ *
+ * A caller that has nothing to declare should not have to say so. The parameter defaults to the empty
+ * chain, as `Modifier` does in Compose, and every wrapper in this library is written that way.
+ *
+ * Only a declaration a caller outside its own file can reach is checked. A private helper is always
+ * called with a chain by the composable that owns it, and a default there would stand for nothing.
+ */
+public class SwingModifierWithoutDefault(
+    config: Config,
+) : Rule(config, "A composable's SwingModifier parameter should default to the empty chain.") {
+    override val ruleName: RuleName = RuleName("SwingModifierWithoutDefault")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (!function.isComposable() || !function.isReachableFromOutside() || function.isImplementingSomething()) {
+            return
+        }
+        function.valueParameters.filter { it.declaresSwingModifier() }.forEach(::reportUnlessDefaultsToTheEmptyChain)
+    }
+
+    private fun reportUnlessDefaultsToTheEmptyChain(parameter: KtParameter) {
+        val default = parameter.defaultValue
+        if (default == null) {
+            report(
+                Finding(
+                    entity = Entity.from(parameter),
+                    message =
+                        "The `${parameter.name}` parameter has no default. Default it to `$SWING_MODIFIER` so a " +
+                            "caller with nothing to declare can leave it out.",
+                ),
+            )
+            return
+        }
+        if (default.isTheEmptyChain()) return
+        report(
+            Finding(
+                entity = Entity.from(default),
+                message =
+                    "The `${parameter.name}` parameter defaults to `${default.text}`, not the empty chain. " +
+                        "Default it to `$SWING_MODIFIER` so a caller with nothing to declare inherits nothing " +
+                        "it did not ask for.",
+            ),
+        )
+    }
+}
+
+private fun KtExpression.isTheEmptyChain(): Boolean {
+    val expression = KtPsiUtil.deparenthesize(this)
+    return when (expression) {
+        is KtDotQualifiedExpression -> {
+            expression.text == SWING_MODIFIER_FQN
+        }
+
+        is KtNameReferenceExpression -> {
+            expression.isLibrarySwingModifierValue()
+        }
+
+        else -> {
+            false
+        }
+    }
+}
+
+internal const val SWING_MODIFIER: String = "SwingModifier"
+
+internal fun KtCallableDeclaration.isComposable(): Boolean =
+    when (this) {
+        is KtProperty -> {
+            annotationEntries.any {
+                it.shortName?.asString() == "Composable" && it.useSiteTarget?.text == "get"
+            } ||
+                getter?.annotationEntries?.any { it.shortName?.asString() == "Composable" } == true
+        }
+
+        else -> {
+            annotationEntries.any { it.shortName?.asString() == "Composable" }
+        }
+    }
+
+/**
+ * Whether a caller outside this library can reach [this]: neither it nor any declaration around it is
+ * private or internal, and it is not local.
+ *
+ * A local property cannot declare a getter, so a property that reaches this check is never local;
+ * locality is checked on a function alone.
+ */
+internal fun KtCallableDeclaration.isReachableFromOutside(): Boolean =
+    (this !is KtNamedFunction || !isLocal) &&
+        !isHiddenFromOutside() &&
+        parents.filterIsInstance<KtClassOrObject>().none { it.isLocal || it.isHiddenFromOutside() }
+
+private fun KtModifierListOwner.isHiddenFromOutside(): Boolean =
+    hasModifier(KtTokens.PRIVATE_KEYWORD) || hasModifier(KtTokens.INTERNAL_KEYWORD)
+
+/**
+ * Whether [this] answers for a signature it did not choose, which a default cannot be added to without
+ * changing what it implements.
+ */
+internal fun KtModifierListOwner.isImplementingSomething(): Boolean =
+    hasModifier(KtTokens.OVERRIDE_KEYWORD) ||
+        hasModifier(KtTokens.ACTUAL_KEYWORD) ||
+        hasModifier(KtTokens.ABSTRACT_KEYWORD)
+
+internal fun KtParameter.declaresSwingModifier(): Boolean = typeReference.declaresSwingModifier()

--- a/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/UnheldColumnComparator.kt
+++ b/swing-ui-detekt/src/main/kotlin/org/jetbrains/compose/swing/detekt/UnheldColumnComparator.kt
@@ -1,0 +1,211 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.parents
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+/**
+ * Reports a `comparator` argument to a table `column` or `addColumn` call that is built where the column
+ * is declared: a lambda, an object expression, or a call other than Compose runtime `remember`.
+ *
+ * A column's comparator is compared by identity, so a new instance on every pass has the table sort its
+ * rows again on each of them, at a cost that grows with the number of rows. Hold one instance instead: a
+ * top-level or member value, or a `remember` in the composable that declares the table.
+ *
+ * The argument is found by its name, `comparator`, rather than by the parameter it fills: a positional
+ * argument is passed over, since telling it apart from `column`'s other positional arguments takes the
+ * parameter's declared type.
+ */
+public class UnheldColumnComparator(
+    config: Config,
+) : Rule(config, "A table column's comparator should be held across passes, not built where the column is declared.") {
+    override val ruleName: RuleName = RuleName("UnheldColumnComparator")
+
+    private companion object {
+        val COLUMN_CALL_NAMES: Set<String> = setOf("column", "addColumn")
+        const val TABLE_PACKAGE: String = "org.jetbrains.compose.swing.components.selection"
+        const val TABLE_FQN: String = "$TABLE_PACKAGE.Table"
+        const val TABLE_NAME: String = "Table"
+        const val COMPARATOR_ARGUMENT_NAME: String = "comparator"
+        const val COMPOSE_RUNTIME_PACKAGE: String = "androidx.compose.runtime"
+        const val COMPOSE_REMEMBER_FQN: String = "$COMPOSE_RUNTIME_PACKAGE.remember"
+        const val REMEMBER_CALL_NAME: String = "remember"
+        const val RUN_CALL_NAME: String = "run"
+        const val MESSAGE: String =
+            "This comparator is built anew on every pass, so the table sorts its rows again on each of them. " +
+                "Hold one instance instead: a top-level or member value, or a `remember` in the composable that " +
+                "declares the table."
+    }
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (!expression.isTableColumnCall()) return
+        val comparator = expression.namedComparatorArgument()?.takeIf { it.buildsANewComparator() } ?: return
+        report(
+            Finding(
+                entity = Entity.from(comparator),
+                message = MESSAGE,
+            ),
+        )
+    }
+
+    private fun KtCallExpression.isTableColumnCall(): Boolean {
+        val calleeName = calleeExpression?.text.orEmpty()
+        val qualifier = (parent as? KtDotQualifiedExpression)?.takeIf { it.selectorExpression === this }
+        val hasUnknownReceiver =
+            qualifier?.receiverExpression?.let { it !is KtThisExpression || it.getLabelName() != null } == true
+        if (calleeName !in COLUMN_CALL_NAMES || isShadowedByCallable(calleeName) || hasUnknownReceiver) {
+            return false
+        }
+        val lambdas = parents.filterIsInstance<KtLambdaExpression>().toList()
+        val tableLambda = lambdas.firstOrNull { it.owningCall()?.isTableCall() == true }
+        return tableLambda != null &&
+            lambdas.takeWhile { it !== tableLambda }.all { it.owningCall()?.isTransparentRunCall() == true }
+    }
+
+    private fun KtLambdaExpression.owningCall(): KtCallExpression? =
+        parents.filterIsInstance<KtCallExpression>().firstOrNull()
+
+    /** A known scope-preserving lambda hop that leaves the table receiver available. */
+    private fun KtCallExpression.isTransparentRunCall(): Boolean {
+        val calleeName = calleeExpression?.text ?: return false
+        val qualifier = (parent as? KtDotQualifiedExpression)?.takeIf { it.selectorExpression === this }
+        val file = containingFile as? KtFile
+        val exactImports =
+            file?.importDirectives?.filter { !it.isAllUnder && it.importedName() == calleeName }.orEmpty()
+        val hasOtherWildcard =
+            file?.importDirectives?.any {
+                it.isAllUnder && it.importPath?.pathStr?.removeSuffix(".*") != "kotlin"
+            } == true
+        return (calleeName == RUN_CALL_NAME && qualifier?.receiverExpression?.text == "kotlin") ||
+            (
+                qualifier == null &&
+                    !isShadowedByCallable(calleeName) &&
+                    (
+                        exactImports.singleOrNull()?.importPath?.pathStr == "kotlin.run" ||
+                            (calleeName == RUN_CALL_NAME && exactImports.isEmpty() && !hasOtherWildcard)
+                    )
+            )
+    }
+
+    private fun KtCallExpression.isTableCall(): Boolean {
+        val calleeName = calleeExpression?.text.orEmpty()
+        val qualifiedParent = (parent as? KtQualifiedExpression)?.takeIf { it.selectorExpression === this }
+        return calleeName.isNotEmpty() &&
+            !isShadowedByCallable(calleeName) &&
+            if (qualifiedParent != null) {
+                qualifiedParent.receiverExpression.text == TABLE_PACKAGE && calleeName == TABLE_NAME
+            } else {
+                (containingFile as? KtFile)?.resolvesImportedName(calleeName, TABLE_FQN) == true
+            }
+    }
+
+    /** Whether a same-file callable makes a PSI-only call target ambiguous. */
+    private fun KtCallExpression.isShadowedByCallable(name: String): Boolean {
+        val file = containingFile as? KtFile
+        return file
+            ?.declarations
+            ?.filterIsInstance<KtNamedDeclaration>()
+            ?.any { it.name == name } == true ||
+            parents.filterIsInstance<KtClassOrObject>().any { owner ->
+                owner.declarations.filterIsInstance<KtNamedDeclaration>().any { it.name == name }
+            } ||
+            parents.filterIsInstance<KtBlockExpression>().any { block ->
+                block.statements.filterIsInstance<KtNamedDeclaration>().any {
+                    it.name == name && (it is KtNamedFunction || it.startOffset < startOffset)
+                }
+            }
+    }
+
+    /**
+     * The expression [this] call's `comparator` argument is passed with, found by the argument's name since
+     * no declared type is available to tell the parameter apart from `column`'s other, positional ones.
+     */
+    private fun KtCallExpression.namedComparatorArgument(): KtExpression? =
+        valueArguments
+            .firstOrNull { it.getArgumentName()?.asName?.identifier == COMPARATOR_ARGUMENT_NAME }
+            ?.getArgumentExpression()
+
+    /**
+     * Whether [this] hands over a comparator built anew each time it is evaluated: a lambda, an object, or a
+     * call other than Compose runtime `remember`. A local name is followed to its initializer; parameters,
+     * members and top-level values outlive the pass and are left alone.
+     */
+    private fun KtExpression.buildsANewComparator(): Boolean =
+        when (val expression = KtPsiUtil.deparenthesize(this)) {
+            is KtLambdaExpression -> {
+                true
+            }
+
+            is KtObjectLiteralExpression -> {
+                true
+            }
+
+            is KtQualifiedExpression -> {
+                (expression.selectorExpression as? KtCallExpression)?.buildsANewComparator() ==
+                    true
+            }
+
+            is KtCallExpression -> {
+                !expression.isComposeRemember()
+            }
+
+            is KtNameReferenceExpression -> {
+                expression.localInitializer()?.buildsANewComparator() == true
+            }
+
+            else -> {
+                false
+            }
+        }
+
+    private fun KtCallExpression.isComposeRemember(): Boolean {
+        val calleeName = calleeExpression?.text ?: return false
+        val qualifier = (parent as? KtDotQualifiedExpression)?.takeIf { it.selectorExpression === this }
+        return if (qualifier != null) {
+            calleeName == REMEMBER_CALL_NAME && qualifier.receiverExpression.text == COMPOSE_RUNTIME_PACKAGE
+        } else {
+            !isShadowedByCallable(calleeName) &&
+                (containingFile as? KtFile)?.resolvesImportedName(calleeName, COMPOSE_REMEMBER_FQN) == true
+        }
+    }
+
+    /**
+     * What the nearest preceding local property visible to [this] was declared with; `null` where the name
+     * instead belongs to a parameter, a member or a top-level value, none of which are rebuilt with the
+     * function that holds this reference. A selector on a receiver, such as a member property, is never a
+     * local and is not followed by name at all.
+     */
+    private fun KtNameReferenceExpression.localInitializer(): KtExpression? {
+        val name = getReferencedName()
+        return getStrictParentOfType<KtNamedFunction>()
+            ?.collectDescendantsOfType<KtProperty> {
+                it.isLocal && it.name == name && it.startOffset < startOffset && it.isVisibleAt(this)
+            }?.maxByOrNull { it.startOffset }
+            ?.initializer
+    }
+
+    private fun KtProperty.isVisibleAt(reference: KtNameReferenceExpression): Boolean =
+        reference.parents.any { it === parent }
+}

--- a/swing-ui-detekt/src/main/resources/META-INF/NOTICE
+++ b/swing-ui-detekt/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,17 @@
+compose-swing-ui :: swing-ui-detekt
+
+This module contains source code copied and adapted from the Android Open Source
+Project's Android Lint checks, redistributed under the Apache License, Version
+2.0.
+
+  Original: compose/ui/ui-lint, ModifierNodeInspectablePropertiesDetector
+            Copyright The Android Open Source Project
+
+Adaptations: the detector reads the code through detekt's rule types and PSI in
+place of Lint's own, and answers about this library's SwingModifier element
+contract in place of Compose UI's ModifierNodeElement. The port is named
+ModifierNodeInspectableProperties and sits in the package
+org.jetbrains.compose.swing.detekt. See its file header for what the port
+substitutes or drops, and for the original copyright year.
+
+A copy of the Apache License 2.0 is in the repository root LICENSE file.

--- a/swing-ui-detekt/src/main/resources/META-INF/services/dev.detekt.api.RuleSetProvider
+++ b/swing-ui-detekt/src/main/resources/META-INF/services/dev.detekt.api.RuleSetProvider
@@ -1,0 +1,2 @@
+org.jetbrains.compose.swing.detekt.ComposeSwingRuleSetProvider
+org.jetbrains.compose.swing.detekt.ComposeSwingInternalRuleSetProvider

--- a/swing-ui-detekt/src/main/resources/config/config.yml
+++ b/swing-ui-detekt/src/main/resources/config/config.yml
@@ -1,0 +1,33 @@
+# What this artifact turns on for anyone who adds it, before their own detekt.yml has a say.
+#
+# Only this artifact's own rulesets appear here. The Compose rules arrive with it and are configured in
+# the consumer's own detekt.yml, because detekt reads every plugin's bundled config as one document and
+# a section two plugins both declare is a duplicate key. swing-ui-detekt/README.md carries that block.
+
+compose-swing:
+  ComposableSwingModifierFactory:
+    active: true
+  ModifierNodeInspectableProperties:
+    active: true
+    # An element declared in a test describes itself to nothing - no tool reads a fixture. Scoped to
+    # the test source set rather than detekt's default `test` segment match, so a published module
+    # whose own package is named "test" stays covered.
+    excludes: ["**/src/test/**"]
+  SwingModifierFactoryExtensionFunction:
+    active: true
+  SwingModifierFactoryReturnType:
+    active: true
+  SwingModifierThen:
+    active: true
+  SwingModifierUnreferencedReceiver:
+    active: true
+  SwingModifierWithoutDefault:
+    active: true
+  UnheldColumnComparator:
+    active: true
+
+compose-swing-internal:
+  PreferImportsOverFqn:
+    active: false
+  PublicDataClass:
+    active: false

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/ComposableSwingModifierFactoryTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/ComposableSwingModifierFactoryTest.kt
@@ -1,0 +1,194 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComposableSwingModifierFactoryTest {
+    private fun lint(source: String) =
+        ComposableSwingModifierFactory(Config.empty).lint(sourceWithLibrarySwingModifierImport(source))
+
+    @Test
+    fun `reports a composable extension on the chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun SwingModifier.highlighted(): SwingModifier = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a composable property getter returning the chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                @get:Composable
+                val SwingModifier.highlighted: SwingModifier
+                    get() = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a plain property getter returning the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                val SwingModifier.highlighted: SwingModifier
+                    get() = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an annotation declared directly on a property getter`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                val SwingModifier.highlighted: SwingModifier
+                    @Composable get() = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a composable property returning an unrelated chain type`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @get:Composable
+                val highlighted: other.SwingModifier
+                    get() = other.SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a composable function returning a chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a composable function returning an aliased chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier as Chain
+
+                @Composable
+                fun highlighted(): Chain = Chain
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a plain factory`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.highlighted(): SwingModifier = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a composable that does not build a chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: SwingModifier = SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a remember function returning what a factory takes`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun rememberHighlights(): Highlights = Highlights()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a composable on the chain that answers with something else`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun SwingModifier.elements(): List<SwingModifier.InspectableElement> = emptyList()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an inferred non-chain return type`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun SwingModifier.value() = 42
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/ComposeSwingRuleSetProviderTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/ComposeSwingRuleSetProviderTest.kt
@@ -1,0 +1,64 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.RuleName
+import dev.detekt.api.RuleSetId
+import dev.detekt.api.RuleSetProvider
+import java.util.ServiceLoader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComposeSwingRuleSetProviderTest {
+    @Test
+    fun `service loader discovers both providers`() {
+        val expected =
+            setOf(
+                ComposeSwingRuleSetProvider::class.java,
+                ComposeSwingInternalRuleSetProvider::class.java,
+            )
+        val discovered =
+            ServiceLoader
+                .load(RuleSetProvider::class.java)
+                .map { it.javaClass }
+                .filter { it in expected }
+                .toSet()
+
+        assertEquals(expected, discovered)
+    }
+
+    @Test
+    fun `public provider registers every published rule`() {
+        val ruleSet = ComposeSwingRuleSetProvider().instance()
+
+        assertEquals(RuleSetId("compose-swing"), ruleSet.id)
+        assertEquals(
+            setOf(
+                RuleName("ComposableSwingModifierFactory"),
+                RuleName("ModifierNodeInspectableProperties"),
+                RuleName("SwingModifierFactoryExtensionFunction"),
+                RuleName("SwingModifierFactoryReturnType"),
+                RuleName("SwingModifierThen"),
+                RuleName("SwingModifierUnreferencedReceiver"),
+                RuleName("SwingModifierWithoutDefault"),
+                RuleName("UnheldColumnComparator"),
+            ),
+            ruleSet.rules.keys,
+        )
+        ruleSet.rules.forEach { (name, createRule) -> assertEquals(name, createRule(Config.empty).ruleName) }
+    }
+
+    @Test
+    fun `internal provider registers only repository rules`() {
+        val ruleSet = ComposeSwingInternalRuleSetProvider().instance()
+
+        assertEquals(RuleSetId("compose-swing-internal"), ruleSet.id)
+        assertEquals(
+            setOf(
+                RuleName("PreferImportsOverFqn"),
+                RuleName("PublicDataClass"),
+            ),
+            ruleSet.rules.keys,
+        )
+        ruleSet.rules.forEach { (name, createRule) -> assertEquals(name, createRule(Config.empty).ruleName) }
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/ModifierNodeInspectablePropertiesTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/ModifierNodeInspectablePropertiesTest.kt
@@ -1,0 +1,287 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ModifierNodeInspectablePropertiesTest {
+    private fun lint(source: String) =
+        ModifierNodeInspectableProperties(Config.empty).lint(sourceWithLibrarySwingModifierImport(source))
+
+    @Test
+    fun `reports an element base subclass that overrides neither member`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                private data class BorderElement(
+                    private val spec: BorderSpec,
+                ) : SwingModifier.NodeElement<JComponent, BorderElement.Node>() {
+                    override val targetType: Class<JComponent> get() = JComponent::class.java
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("overrides neither `name` nor `declaredValues`"))
+    }
+
+    @Test
+    fun `reports an element implementing the interface directly`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                internal data class KeyElement(
+                    val tokens: List<Any?>,
+                ) : SwingModifier.Element,
+                    SwingModifier.InspectableElement
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an element qualified by an alias of the library chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier as Chain
+
+                internal data class KeyElement(
+                    val tokens: List<Any?>,
+                ) : Chain.InspectableElement
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an element declaring name as a function rather than overriding the property`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                private class ToolTipElement(private val text: String) :
+                    SwingModifier.NodeElement<JComponent, Node>() {
+                    fun name(): String = text
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an element whose nested class is the one declaring a name`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                private class ToolTipElement(private val text: String) :
+                    SwingModifier.NodeElement<JComponent, ToolTipElement.Node>() {
+                    class Node : SwingModifier.Node<JComponent>() {
+                        val name: String = "toolTip"
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an element built from nothing`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private object InitialFocusElement : SwingModifier.NodeElement<Component, Node>() {
+                    override fun create(): Node = Node()
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an element carrying only a callback`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private class ClickElement(
+                    private val onClick: () -> Unit,
+                ) : SwingModifier.NodeElement<Component, Node>()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated type with the same simple name`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private class BorderElement(
+                    private val width: Int,
+                ) : Other.NodeElement<Component>()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated type with a doubly qualified SwingModifier`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private class BorderElement(
+                    private val width: Int,
+                ) : Other.SwingModifier.NodeElement<Component>()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a consumer SwingModifier NodeElement`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import consumer.SwingModifier
+
+                private data class ItemElement(val value: String) : SwingModifier.NodeElement<ItemElement>()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an element that overrides only the name`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private object InitialFocusElement : SwingModifier.NodeElement<Component, Node>() {
+                    override val name: String get() = "initialFocus"
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an element that overrides only the values it declares`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private data class BorderElement(
+                    private val spec: BorderSpec,
+                ) : SwingModifier.NodeElement<JComponent, BorderElement.Node>() {
+                    override val declaredValues: Map<String, Any?> get() = mapOf("border" to spec)
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a shared seam taking its name as a constructor property`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                internal open class PropertyElement<T, V>(
+                    override val name: String,
+                    private val value: V,
+                ) : SwingModifier.NodeElement<T, PropertyNode<T, V>>()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an interface or an abstract class that leaves both to its implementors`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                internal interface PlacementElement :
+                    SwingModifier.Element,
+                    SwingModifier.InspectableElement
+
+                internal abstract class NamedElement : SwingModifier.InspectableElement
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a class inheriting the overrides from its own base`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                internal open class BaseElement : SwingModifier.InspectableElement {
+                    override val name: String get() = "base"
+                }
+
+                internal class InheritingElement : BaseElement()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a class that is not a modifier element`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                internal data class BorderSpec(
+                    val width: Int,
+                ) : Comparable<BorderSpec> {
+                    override fun compareTo(other: BorderSpec): Int = width - other.width
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/PreferImportsOverFqnTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/PreferImportsOverFqnTest.kt
@@ -1,0 +1,153 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PreferImportsOverFqnTest {
+    @Test
+    fun `reports direct FQN in type reference`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                class Demo(val value: org.jetbrains.compose.swing.sample.Widget)
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertEquals(
+            "Use import instead of direct FQN: org.jetbrains.compose.swing.sample.Widget",
+            findings.single().message,
+        )
+    }
+
+    @Test
+    fun `reports direct FQN for a nested type reference`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                class Demo(val value: java.util.Map.Entry<String, String>)
+                """.trimIndent(),
+            )
+
+        assertEquals(
+            listOf("Use import instead of direct FQN: java.util.Map.Entry"),
+            findings.map { it.message },
+        )
+    }
+
+    @Test
+    fun `does not report when type is imported`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.sample.Widget
+
+                class Demo(val value: Widget)
+                """.trimIndent(),
+            )
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not inspect expression call chains`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                fun serialize(model: Any, output: java.io.File) {
+                    sample.serialization.ModelSerializer.serialize(model, output)
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(
+            listOf("Use import instead of direct FQN: java.io.File"),
+            findings.map { it.message },
+        )
+    }
+
+    @Test
+    fun `does not report regular member access chain`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                fun path(project: Any) {
+                    project.toString()
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not report member chains rooted at a value`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                fun serialize(namespace: Namespace) {
+                    namespace.Serializer.serialize()
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not report FQN text inside string literals`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                val value = "org.jetbrains.compose.swing.sample.Widget"
+                """.trimIndent(),
+            )
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `supports suppression by rule id`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                @Suppress("PreferImportsOverFqn")
+                class Demo(val value: org.jetbrains.compose.swing.sample.Widget)
+                """.trimIndent(),
+            )
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `reports a fully qualified nullable type`() {
+        val findings =
+            PreferImportsOverFqn(Config.empty).lint(
+                """
+                package sample
+
+                class Demo(val value: org.jetbrains.compose.swing.sample.Widget?)
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/PublicDataClassTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/PublicDataClassTest.kt
@@ -1,0 +1,192 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PublicDataClassTest {
+    private fun lint(source: String) = PublicDataClass(Config.empty).lint(source)
+
+    private fun assertReported(source: String) =
+        assertEquals(1, lint(source).size, "expected one finding for:\n$source")
+
+    private fun assertClean(source: String) =
+        assertEquals(emptyList(), lint(source), "expected no finding for:\n$source")
+
+    @Test
+    fun `reports a data class declared public`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                public data class Point(val x: Int, val y: Int)
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("copy"))
+    }
+
+    @Test
+    fun `reports a data class with no visibility keyword`() {
+        assertReported(
+            """
+            package sample
+
+            data class Point(val x: Int, val y: Int)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `reports a protected data class, the surface a subclass compiles against`() {
+        assertReported(
+            """
+            package sample
+
+            open class Holder {
+                protected data class Row(val value: Int)
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `reports a data class nested in a public class`() {
+        assertReported(
+            """
+            package sample
+
+            class Holder {
+                data class Row(val value: Int)
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `reports a data class in the companion of a public class`() {
+        assertReported(
+            """
+            package sample
+
+            class Holder {
+                companion object {
+                    data class Row(val value: Int)
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over an internal data class`() {
+        assertClean(
+            """
+            package sample
+
+            internal data class Point(val x: Int, val y: Int)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a private data class`() {
+        assertClean(
+            """
+            package sample
+
+            private data class Point(val x: Int, val y: Int)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a data class declared inside a function`() {
+        assertClean(
+            """
+            package sample
+
+            fun build() {
+                data class Point(val x: Int, val y: Int)
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a data class nested in an internal class`() {
+        assertClean(
+            """
+            package sample
+
+            internal class Holder {
+                data class Row(val value: Int)
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a data class nested in a private class`() {
+        assertClean(
+            """
+            package sample
+
+            private class Holder {
+                data class Row(val value: Int)
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a data class declared public inside an internal object`() {
+        assertClean(
+            """
+            package sample
+
+            internal object Impl {
+                public data class Row(val value: Int)
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a class that is not a data class`() {
+        assertClean(
+            """
+            package sample
+
+            public class Point(val x: Int, val y: Int)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a value class`() {
+        assertClean(
+            """
+            package sample
+
+            @JvmInline
+            public value class Pixels(val value: Int)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `passes over a data object, which generates no constructor-shaped members`() {
+        assertClean(
+            """
+            package sample
+
+            public data object Origin
+            """.trimIndent(),
+        )
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierChainingTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierChainingTest.kt
@@ -1,0 +1,777 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SwingModifierUnreferencedReceiverTest {
+    private fun lint(source: String) =
+        SwingModifierUnreferencedReceiver(Config.empty).lint(sourceWithLibrarySwingModifierImport(source))
+
+    @Test
+    fun `does not report an accessor on the chain that answers with something else`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                private fun SwingModifier.elements(): List<SwingModifier.InspectableElement> =
+                    foldIn(mutableListOf<SwingModifier.InspectableElement>()) { acc, element ->
+                        acc.apply { if (element is SwingModifier.InspectableElement) add(element) }
+                    }
+                """.trimIndent(),
+            )
+
+        assertEquals(0, findings.size, findings.joinToString { it.message })
+    }
+
+    @Test
+    fun `reports a block body that returns a fresh chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(): SwingModifier {
+                    val extra = Highlight()
+                    return SwingModifier.then(extra)
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fresh chain in an explicit return branch`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(condition: Boolean): SwingModifier {
+                    return if (condition) SwingModifier.then(Highlight()) else this
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not treat a block body's final expression as its return value`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.notAFactory() {
+                    SwingModifier.then(Highlight())
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fresh chain in a terminal if branch`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(condition: Boolean): SwingModifier =
+                    if (condition) SwingModifier.then(Highlight()) else this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fresh chain in a terminal when branch`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(value: Int): SwingModifier =
+                    when (value) {
+                        0 -> SwingModifier.then(Highlight())
+                        else -> this
+                    }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fresh chain in a terminal try body`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(): SwingModifier =
+                    try {
+                        SwingModifier.then(Highlight())
+                    } catch (_: Exception) {
+                        this
+                    }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report terminal control flow that keeps the receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.preserved(condition: Boolean): SwingModifier =
+                    if (condition) this else this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a fresh chain returned only by a nested function`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.preserved(): SwingModifier {
+                    fun discarded(): SwingModifier = SwingModifier.then(Highlight())
+                    return this
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a fresh chain returned only by a nested anonymous function`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.preserved(): SwingModifier {
+                    val discarded = fun(): SwingModifier {
+                        return SwingModifier.then(Highlight())
+                    }
+                    return this
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fresh chain returned non-locally from a lambda`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(): SwingModifier {
+                    listOf(1).forEach {
+                        return SwingModifier.then(Highlight())
+                    }
+                    return this
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a chain the receiver opens with infix then`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.highlighted(): SwingModifier = (this then Highlight()) then Border()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a factory that hands the empty chain to an element while chaining onto its receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.boxed(): SwingModifier = then(BoxElement(inner = SwingModifier))
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fresh chain even where the body names this inside a lambda`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(): SwingModifier =
+                    SwingModifier.then(Highlight()).also { c -> c.apply { this.hashCode() } }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a factory that starts a fresh chain from SwingModifier itself`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.dropped(): SwingModifier = SwingModifier.then(Highlight())
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("`dropped` factory returns a chain built from"))
+    }
+
+    @Test
+    fun `reports a factory that hands back the empty chain by name`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.reset(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a factory that hands back an aliased empty chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier as Chain
+
+                fun Chain.reset(): Chain = Chain
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a factory that chains directly onto its receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.explicit(): SwingModifier = this.then(Highlight())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a factory delegating through an implicit receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.explicit(): SwingModifier = this.then(Highlight())
+
+                fun SwingModifier.delegating(): SwingModifier = explicit()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a nullable receiver that falls back to the empty chain, since it also names this`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier?.dimmed(): SwingModifier = this ?: SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a function without a chain receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun dropped(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not infer that an expression body returns the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.hash() = SwingModifier.then(Highlight()).hashCode()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a property getter that starts a fresh chain from SwingModifier itself`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                val SwingModifier.dropped: SwingModifier get() = SwingModifier.then(Highlight())
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("`dropped` factory returns a chain built from"))
+    }
+
+    @Test
+    fun `does not report a fresh chain returned only by a nested getter function`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                val SwingModifier.preserved: SwingModifier
+                    get() {
+                        fun discarded(): SwingModifier = SwingModifier.then(Highlight())
+                        return this
+                    }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a fresh chain returned only by a nested accessor`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.preserved(): SwingModifier {
+                    class Holder {
+                        val discarded: SwingModifier
+                            get() {
+                                return SwingModifier.then(Highlight())
+                            }
+                    }
+                    return this
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a property getter that chains directly onto its receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                val SwingModifier.explicit: SwingModifier get() = this.then(Highlight())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `recognizes an explicitly labeled factory receiver inside a lambda`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.preserved(): SwingModifier =
+                    SwingModifier.then(Highlight()).also { this@preserved.hashCode() }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}
+
+class SwingModifierThenTest {
+    private fun lint(source: String) =
+        SwingModifierThen(Config.empty).lint(sourceWithLibrarySwingModifierImport(source))
+
+    @Test
+    fun `reports a factory taking its receiver implicitly inside then`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.doubled(): SwingModifier = this.then(padded())
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("chains the receiver twice"))
+    }
+
+    @Test
+    fun `reports a factory taking its receiver implicitly inside a bare then call`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.doubled(): SwingModifier = then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a bare then call shadowed by a local function`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.preserved(): SwingModifier {
+                    fun then(chain: SwingModifier): SwingModifier = chain
+                    return then(padded())
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a bare then call shadowed by a local property`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.preserved(): SwingModifier {
+                    val then: (SwingModifier) -> SwingModifier = { it }
+                    return then(padded())
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a bare then call outside a chain extension`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+                fun then(chain: SwingModifier): SwingModifier = chain
+
+                fun preserved(): SwingModifier = then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a factory taking its receiver implicitly inside infix then`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.doubled(): SwingModifier = this then padded()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("chains the receiver twice"))
+    }
+
+    @Test
+    fun `reports a property getter taking its receiver implicitly inside then`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                val SwingModifier.doubled: SwingModifier
+                    get() = this.then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an explicitly labeled chain receiver inside then`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.doubled(): SwingModifier = run {
+                    this@doubled.then(padded())
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report infix then given a chain that starts from the empty one`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.explicit(): SwingModifier = this then SwingModifier.padded()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report chaining directly onto the receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.chained(): SwingModifier = this.padded()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a factory given the empty chain explicitly`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.explicit(): SwingModifier = this.then(SwingModifier.padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report then called on the empty chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.explicit(): SwingModifier = SwingModifier.then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report another receiver's then call`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                class Other {
+                    fun then(chain: SwingModifier): SwingModifier = chain
+                }
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.preserved(other: Other): SwingModifier = other.then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report another receiver's infix then call`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                class Other {
+                    infix fun then(chain: SwingModifier): SwingModifier = chain
+                }
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.preserved(other: Other): SwingModifier = other then padded()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report then given a plain value`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.other(that: SwingModifier): SwingModifier = this.then(that)
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a bare call to a function that is not declared on the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private fun layerDepth(layer: Int): SwingModifier = SwingModifier
+
+                fun SwingModifier.layer(layer: Int): SwingModifier = this.then(layerDepth(1))
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not guess between same named top level overloads`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+                fun padded(): SwingModifier = SwingModifier
+
+                fun SwingModifier.doubled(): SwingModifier = this.then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not use a nested factory that the call cannot see`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun holder() {
+                    fun SwingModifier.padded(): SwingModifier = this
+                }
+
+                fun SwingModifier.doubled(): SwingModifier = this.then(padded())
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a top level factory shadowed by a local function`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded(): SwingModifier = this
+
+                fun SwingModifier.doubled(): SwingModifier {
+                    fun padded(): SwingModifier = SwingModifier
+                    return this.then(padded())
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierFactoryShapeTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierFactoryShapeTest.kt
@@ -1,0 +1,542 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SwingModifierFactoryReturnTypeTest {
+    private fun lint(source: String) =
+        SwingModifierFactoryReturnType(Config.empty).lint(
+            sourceWithLibrarySwingModifierImport(source),
+        )
+
+    @Test
+    fun `reports a chain extension that returns the element it builds`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.highlighted(): Highlight = Highlight()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("returns `Highlight`"))
+    }
+
+    @Test
+    fun `does not report a chain extension that returns the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.highlighted(): SwingModifier = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a nullable chain extension that returns the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier?.dimmed(): SwingModifier = this ?: SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a function without a chain receiver, which is not a factory candidate`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun highlighted(): Highlight = Highlight()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a function with an inferred return type`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.padded() = PadElement()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a private chain extension, which is not reachable from outside`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private fun SwingModifier.highlighted(): Highlight = Highlight()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fully qualified element return type`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.highlighted(): sample.elements.Highlight = Highlight()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+    }
+
+    @Test
+    fun `reports a chain extension property that returns the element it builds`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                val SwingModifier.highlighted: Highlight get() = Highlight()
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("returns `Highlight`"))
+    }
+
+    @Test
+    fun `does not report a chain extension property that returns the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                val SwingModifier.highlighted: SwingModifier get() = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a var property, which is not a factory candidate`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                var SwingModifier.highlighted: Highlight
+                    get() = Highlight()
+                    set(_) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a stored property with no getter, which is not a factory candidate`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                val highlighted: Highlight = Highlight()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a member property, which is not a factory candidate`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                class Widget {
+                    val SwingModifier.highlighted: Highlight get() = Highlight()
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}
+
+class SwingModifierFactoryExtensionFunctionTest {
+    private fun lint(source: String) =
+        SwingModifierFactoryExtensionFunction(Config.empty).lint(sourceWithLibrarySwingModifierImport(source))
+
+    @Test
+    fun `reports a chain factory with no receiver`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("`highlighted` factory is not an extension"))
+    }
+
+    @Test
+    fun `reports a chain factory whose receiver is not the chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun String.highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a plain extension on the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier.highlighted(): SwingModifier = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a nullable extension on the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun SwingModifier?.dimmed(): SwingModifier = this ?: SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a function that does not return the chain, which is not a factory candidate`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun highlighted(): Highlight = Highlight()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a private function off the chain, which is not reachable from outside`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                private fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated qualified return type with the chain simple name`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun highlighted(): sample.modifier.SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated qualified chain receiver`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun Other.SwingModifier.highlighted(): Highlight = Highlight()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a factory returning the library chain without a receiver`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun highlighted(): org.jetbrains.compose.swing.modifier.SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated qualified chain return type`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun highlighted(): Other.SwingModifier = Other.SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a consumer-defined chain type imported under the library name`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import consumer.SwingModifier
+
+                fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a same-file declaration that shadows the library chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                class SwingModifier
+
+                fun highlighted(): SwingModifier = SwingModifier()
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `recognizes the chain type beside a value with the same name`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                val SwingModifier: Any = Any()
+
+                fun highlighted(): SwingModifier = error("unused")
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a chain type shadowed by a nested declaration`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier
+
+                class Container {
+                    class SwingModifier
+
+                    fun factory(): SwingModifier = SwingModifier()
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a chain type shadowed by a type parameter`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier
+
+                fun <SwingModifier> factory(): SwingModifier = error("unused")
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `recognizes an unambiguous wildcard import of the library chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.*
+
+                fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `explicit library import wins over an unrelated wildcard import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import java.util.*
+                import org.jetbrains.compose.swing.modifier.SwingModifier
+
+                fun padded(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `test fixture adds the library import alongside an unrelated import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import java.util.*
+
+                fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `recognizes an explicit alias of the library chain`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier as Chain
+
+                fun padded(): Chain = Chain
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `recognizes the library chain from its own package without an import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package org.jetbrains.compose.swing.modifier
+
+                fun highlighted(): SwingModifier = SwingModifier
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a chain property with no receiver`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                val highlighted: SwingModifier get() = SwingModifier
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("Declare it as `val SwingModifier.highlighted"))
+    }
+
+    @Test
+    fun `does not report a property extension on the chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                val SwingModifier.highlighted: SwingModifier get() = this
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a var property, which is not a factory candidate`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                var highlighted: SwingModifier
+                    get() = SwingModifier
+                    set(_) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierTestSource.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierTestSource.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.compose.swing.detekt
+
+private const val LIBRARY_SWING_MODIFIER_IMPORT =
+    "import org.jetbrains.compose.swing.modifier.SwingModifier"
+
+internal fun sourceWithLibrarySwingModifierImport(source: String): String =
+    if (
+        source.lineSequence().any { it.importsSwingModifierName() } ||
+        source.contains("import org.jetbrains.compose.swing.modifier.*") ||
+        source.contains("package org.jetbrains.compose.swing.modifier")
+    ) {
+        source
+    } else {
+        source.replaceFirst("package sample", "package sample\n\n$LIBRARY_SWING_MODIFIER_IMPORT")
+    }
+
+private fun String.importsSwingModifierName(): Boolean {
+    val directive = trim().removePrefix("import ")
+    if (directive == trim()) return false
+    val path = directive.substringBefore(" as ")
+    val alias = directive.substringAfter(" as ", missingDelimiterValue = "")
+    val importedName = alias.ifEmpty { path.substringAfterLast('.') }
+    return path == "org.jetbrains.compose.swing.modifier.SwingModifier" || importedName == "SwingModifier"
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierWithoutDefaultTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/SwingModifierWithoutDefaultTest.kt
@@ -1,0 +1,287 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SwingModifierWithoutDefaultTest {
+    private fun lint(source: String) =
+        SwingModifierWithoutDefault(Config.empty).lint(sourceWithLibrarySwingModifierImport(source))
+
+    @Test
+    fun `does not report an unrelated qualified chain type`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: other.SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated qualified chain type with its own default`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Label(modifier: other.SwingModifier = other.SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a public composable whose chain parameter has no default`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: SwingModifier) = Unit
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("`modifier` parameter has no default"))
+    }
+
+    @Test
+    fun `does not report a defaulted chain parameter`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: SwingModifier = SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a private helper, which is always handed a chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                private fun WidgetNode(modifier: SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an internal helper`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                internal fun WidgetNode(modifier: SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an override, whose signature is not its own to change`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                override fun Widget(modifier: SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a function that is not composable`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun widget(modifier: SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a fully qualified chain type`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: org.jetbrains.compose.swing.modifier.SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a chain parameter defaulted to something other than the empty chain`() {
+        val findings =
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: SwingModifier = SwingModifier.padded()) = Unit
+                """.trimIndent(),
+            )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("defaults to `SwingModifier.padded()`, not the empty chain"))
+    }
+
+    @Test
+    fun `does not report a chain parameter defaulted to the fully qualified empty chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Widget(modifier: SwingModifier = org.jetbrains.compose.swing.modifier.SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a chain parameter defaulted to another type with the same simple name`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import consumer.Other
+
+                @Composable
+                fun Label(modifier: SwingModifier = Other.SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `accepts an imported alias for the empty chain`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier as Chain
+
+                @Composable
+                fun Label(modifier: Chain = Chain) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a value that shadows the empty chain companion`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                @Composable
+                fun Label(
+                    SwingModifier: Any,
+                    modifier: SwingModifier = SwingModifier,
+                ) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a top-level value that shadows the empty chain companion`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                val SwingModifier: Any = Any()
+
+                @Composable
+                fun Label(modifier: SwingModifier = SwingModifier) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an imported chain alias without a default`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.modifier.SwingModifier as Chain
+
+                @Composable
+                fun Label(modifier: Chain) = Unit
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a composable no caller outside the module can reach`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                internal object Internals {
+                    @Composable
+                    fun Widget(modifier: SwingModifier) = Unit
+                }
+
+                @Composable
+                fun Host() {
+                    @Composable
+                    fun Local(modifier: SwingModifier) = Unit
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}

--- a/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/UnheldColumnComparatorTest.kt
+++ b/swing-ui-detekt/src/test/kotlin/org/jetbrains/compose/swing/detekt/UnheldColumnComparatorTest.kt
@@ -1,0 +1,725 @@
+package org.jetbrains.compose.swing.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UnheldColumnComparatorTest {
+    private fun lint(source: String) = UnheldColumnComparator(Config.empty).lint(source)
+
+    private fun lintTable(body: String) =
+        lint(
+            """
+            package sample
+
+            import org.jetbrains.compose.swing.components.selection.Table
+
+            fun table() {
+                Table(rows = emptyList<String>()) {
+                    $body
+                }
+            }
+            """.trimIndent(),
+        )
+
+    @Test
+    fun `reports a comparator built with a call where the column is declared`() {
+        val findings =
+            lintTable("column(\"Name\", comparator = compareBy<String> { it }) { it }")
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("built anew on every pass"))
+    }
+
+    @Test
+    fun `reports a comparator built with a lambda where the column is declared`() {
+        assertEquals(
+            1,
+            lintTable("column(\"Name\", comparator = { a: String, b: String -> a.compareTo(b) }) { it }").size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator built through an explicit table receiver`() {
+        assertEquals(
+            1,
+            lintTable("this.column(\"Name\", comparator = compareBy<String> { it }) { it }").size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator built inside a transparent run block`() {
+        assertEquals(
+            1,
+            lintTable(
+                """
+                run {
+                    column("Name", comparator = compareBy<String> { it }) { it }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator built inside a qualified Kotlin run block`() {
+        assertEquals(
+            1,
+            lintTable(
+                """
+                kotlin.run {
+                    column("Name", comparator = compareBy<String> { it }) { it }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not follow a run imported from another package`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import other.run
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        run {
+                            column("Name", comparator = compareBy<String> { it }) { it }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not follow a run from an unrelated wildcard import`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import other.*
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        run {
+                            column("Name", comparator = compareBy<String> { it }) { it }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `explicit Kotlin run wins over an unrelated wildcard import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import kotlin.run
+                import other.*
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        run {
+                            column("Name", comparator = compareBy<String> { it }) { it }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator built inside an aliased Kotlin run block`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import kotlin.run as withScope
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        withScope {
+                            column("Name", comparator = compareBy<String> { it }) { it }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator built with an object expression`() {
+        assertEquals(
+            1,
+            lintTable(
+                """
+                column(
+                    "Name",
+                    comparator =
+                        object : Comparator<String> {
+                            override fun compare(first: String, second: String): Int = 0
+                        },
+                ) { it }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator declared through addColumn`() {
+        assertEquals(
+            1,
+            lintTable("addColumn(\"Name\", true, comparator = compareBy<String> { it }, value = { it })").size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator held by a local variable built where the column is declared`() {
+        assertEquals(
+            1,
+            lintTable(
+                """
+                val byName = compareBy<String> { it }
+                column("Name", comparator = byName) { it }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `follows a local variable declared in the composable across the block that declares the columns`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun people(names: List<String>) {
+                    val byName = compareBy<String> { it }
+                    Table(names) {
+                        column("Name", comparator = byName) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a comparator built by a qualified call where the column is declared`() {
+        assertEquals(
+            1,
+            lintTable("column(\"Name\", comparator = Comparators.byName()) { it }").size,
+        )
+    }
+
+    @Test
+    fun `does not report a comparator produced by a type cast, which this rule does not follow`() {
+        assertEquals(
+            0,
+            lintTable(
+                "column(\"Name\", comparator = String.CASE_INSENSITIVE_ORDER as Comparator<String>) { it }",
+            ).size,
+        )
+    }
+
+    @Test
+    fun `follows a local variable through another local variable to what built the comparator`() {
+        assertEquals(
+            1,
+            lintTable(
+                """
+                val base = compareBy<String> { it }
+                val byName = base
+                column("Name", comparator = byName) { it }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a comparator held across passes by remember`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import androidx.compose.runtime.remember
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        val byName = remember { compareBy<String> { it } }
+                        column("Name", comparator = byName) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a comparator held by an aliased Compose remember`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import androidx.compose.runtime.remember as retain
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = retain { compareBy<String> { it } }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a comparator held by fully qualified Compose remember`() {
+        assertEquals(
+            0,
+            lintTable(
+                """
+                column(
+                    "Name",
+                    comparator = androidx.compose.runtime.remember { compareBy<String> { it } },
+                ) { it }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a comparator held by wildcard imported Compose remember`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import androidx.compose.runtime.*
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = remember { compareBy<String> { it } }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an unrelated call named remember`() {
+        assertEquals(
+            1,
+            lintTable(
+                "column(\"Name\", comparator = remember { compareBy<String> { it } }) { it }",
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports an explicitly imported unrelated remember`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import other.remember
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = remember { compareBy<String> { it } }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a qualified unrelated remember`() {
+        assertEquals(
+            1,
+            lintTable(
+                "column(\"Name\", comparator = other.remember { compareBy<String> { it } }) { it }",
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a local remember function shadowing the Compose import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import androidx.compose.runtime.remember
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    fun <T> remember(block: () -> T): T = block()
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = remember { compareBy<String> { it } }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a local remember property shadowing the Compose import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import androidx.compose.runtime.remember
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table() {
+                    val remember: (() -> Comparator<String>) -> Comparator<String> = { it() }
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = remember { compareBy<String> { it } }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a member remember function shadowing the Compose import`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import androidx.compose.runtime.remember
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                class Screen {
+                    fun <T> remember(block: () -> T): T = block()
+
+                    fun table() {
+                        Table(rows = emptyList<String>()) {
+                            column("Name", comparator = remember { compareBy<String> { it } }) { it }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}
+
+class UnheldColumnComparatorScopeTest {
+    private fun lint(source: String) = UnheldColumnComparator(Config.empty).lint(source)
+
+    private fun lintTable(body: String) =
+        lint(
+            """
+            package sample
+
+            import org.jetbrains.compose.swing.components.selection.Table
+
+            fun table() {
+                Table(rows = emptyList<String>()) {
+                    $body
+                }
+            }
+            """.trimIndent(),
+        )
+
+    @Test
+    fun `does not report a comparator passed in as a parameter, which outlives the pass`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table(byName: Comparator<String>) {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = byName) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not resolve a parameter to a same named local in a sibling scope`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun table(byName: Comparator<String>) {
+                    run {
+                        val byName = compareBy<String> { it }
+                        consume(byName)
+                    }
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = byName) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a top-level comparator, which outlives the pass`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                private val byName = compareBy<String> { it }
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = byName) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a positional comparator argument, which a name alone cannot tell apart`() {
+        assertEquals(
+            0,
+            lintTable("column(\"Name\", compareBy<String> { it }) { it }").size,
+        )
+    }
+
+    @Test
+    fun `does not report a call that is not a column declaration`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun sortRows() {
+                    reorder(comparator = compareBy<String> { it })
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated local function named column`() {
+        assertEquals(
+            0,
+            lintTable(
+                """
+                fun column(comparator: Comparator<String>) = comparator
+                column(comparator = compareBy<String> { it })
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a column inside a Table imported through an alias`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table as Grid
+
+                fun table() {
+                    Grid(rows = emptyList<String>()) {
+                        column("Name", comparator = compareBy<String> { it }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a column inside a fully qualified Table call`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                fun table() {
+                    org.jetbrains.compose.swing.components.selection.Table(rows = emptyList<String>()) {
+                        column("Name", comparator = compareBy<String> { it }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a column inside a wildcard imported Table`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.*
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = compareBy<String> { it }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `reports a column inside Table from its own package`() {
+        assertEquals(
+            1,
+            lint(
+                """
+                package org.jetbrains.compose.swing.components.selection
+
+                fun table() {
+                    Table(rows = emptyList<String>()) {
+                        column("Name", comparator = compareBy<String> { it }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report an unrelated top-level column function`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun column(comparator: Comparator<String>) = comparator
+
+                fun sortRows() {
+                    Table(rows = emptyList<String>()) {
+                        column(comparator = compareBy<String> { it })
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a qualified unrelated column call`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                fun sortRows(scope: Any) {
+                    scope.column(comparator = compareBy<String> { it })
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a column in a nested receiver scope`() {
+        assertEquals(
+            0,
+            lintTable(
+                """
+                Other().run {
+                    column(comparator = compareBy<String> { it })
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+
+    @Test
+    fun `does not report a column inside a same-file Table shadow`() {
+        assertEquals(
+            0,
+            lint(
+                """
+                package sample
+
+                import org.jetbrains.compose.swing.components.selection.Table
+
+                fun Table(rows: List<String>, block: () -> Unit) = block()
+
+                fun table() {
+                    Table(emptyList()) {
+                        column("Name", comparator = compareBy<String> { it }) { it }
+                    }
+                }
+                """.trimIndent(),
+            ).size,
+        )
+    }
+}

--- a/swing-ui-test/build.gradle.kts
+++ b/swing-ui-test/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
 
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
-        enabled.set(true)
         filters {
             exclude {
                 annotatedWith.add("org.jetbrains.compose.swing.annotations.InternalSwingUiApi")

--- a/swing-ui-test/src/test/kotlin/org/jetbrains/compose/swing/test/ComposeSwingTestSmokeTest.kt
+++ b/swing-ui-test/src/test/kotlin/org/jetbrains/compose/swing/test/ComposeSwingTestSmokeTest.kt
@@ -19,8 +19,8 @@ class ComposeSwingTestSmokeTest {
     fun clickRecomposesAndUpdatesLabel() = runComposeSwingTest {
         val count = mutableIntStateOf(0)
         setContent {
-            Button(text = "Increment", onClick = { count.value++ })
-            Label(text = "Count: ${count.value}")
+            Button(text = "Increment", onClick = { count.intValue++ })
+            Label(text = "Count: ${count.intValue}")
         }
 
         onNodeWithText("Count: 0").assertExists()

--- a/swing-ui/api/swing-ui.api
+++ b/swing-ui/api/swing-ui.api
@@ -38,7 +38,7 @@ public final class org/jetbrains/compose/swing/components/ComponentsKt {
 public final class org/jetbrains/compose/swing/components/ComposableSingletons$TrayKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/ComposableSingletons$TrayKt;
 	public fun <init> ()V
-	public final fun getLambda$-1905108586$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1905108586$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/button/ButtonComponentsKt {
@@ -184,25 +184,25 @@ public abstract interface class org/jetbrains/compose/swing/components/layout/Co
 public final class org/jetbrains/compose/swing/components/layout/ComposableSingletons$BoxPanelKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/layout/ComposableSingletons$BoxPanelKt;
 	public fun <init> ()V
-	public final fun getLambda$1819195700$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1819195700$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/layout/ComposableSingletons$FlowPanelKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/layout/ComposableSingletons$FlowPanelKt;
 	public fun <init> ()V
-	public final fun getLambda$1343816618$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1343816618$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/layout/ComposableSingletons$GridPanelKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/layout/ComposableSingletons$GridPanelKt;
 	public fun <init> ()V
-	public final fun getLambda$1253374999$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1253374999$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/layout/ComposableSingletons$ToolBarKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/layout/ComposableSingletons$ToolBarKt;
 	public fun <init> ()V
-	public final fun getLambda$-965484763$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-965484763$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public abstract interface class org/jetbrains/compose/swing/components/layout/GridBagPanelScope {
@@ -283,19 +283,19 @@ public abstract interface class org/jetbrains/compose/swing/components/layout/Ta
 public final class org/jetbrains/compose/swing/components/menu/ComposableSingletons$ContextMenuKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/menu/ComposableSingletons$ContextMenuKt;
 	public fun <init> ()V
-	public final fun getLambda$790984614$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$790984614$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/menu/ComposableSingletons$MenuKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/menu/ComposableSingletons$MenuKt;
 	public fun <init> ()V
-	public final fun getLambda$-1876829487$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1876829487$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/menu/ComposableSingletons$PopupMenuKt {
 	public static final field INSTANCE Lorg/jetbrains/compose/swing/components/menu/ComposableSingletons$PopupMenuKt;
 	public fun <init> ()V
-	public final fun getLambda$1300389638$swing_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1300389638$org_jetbrains_compose_swing_swing_ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/compose/swing/components/menu/MenuComponentsKt {
@@ -1113,7 +1113,6 @@ public final class org/jetbrains/compose/swing/window/WindowPosition$PlatformDef
 
 public final class org/jetbrains/compose/swing/window/WindowScope {
 	public static final field $stable I
-	public synthetic fun <init> (Ljavax/swing/JRootPane;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class org/jetbrains/compose/swing/window/WindowState {

--- a/swing-ui/build.gradle.kts
+++ b/swing-ui/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
 
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
-        enabled.set(true)
         filters {
             exclude {
                 annotatedWith.add("org.jetbrains.compose.swing.annotations.InternalSwingUiApi")

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/layout/BoxFillers.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/layout/BoxFillers.kt
@@ -4,6 +4,7 @@
 package org.jetbrains.compose.swing.components.layout
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
 import org.jetbrains.compose.swing.constants.Orientation
 import org.jetbrains.compose.swing.modifier.SwingModifier
 import org.jetbrains.compose.swing.node.SwingNode
@@ -33,6 +34,7 @@ import javax.swing.SwingConstants
  * @see javax.swing.Box.Filler
  */
 @Composable
+@NonRestartableComposable
 public fun RigidArea(
     width: Int,
     height: Int,

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/layout/ScrollPaneScope.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/layout/ScrollPaneScope.kt
@@ -338,7 +338,7 @@ private val ColumnHeaderAttachment =
  * is moved by the name rather than by this attachment.
  */
 private class CornerAttachment(
-    @ScrollPaneCorner val corner: String,
+    @param:ScrollPaneCorner val corner: String,
 ) : SlotAttachment {
     override fun install(
         host: Container,

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/menu/RadioButtonMenuGroup.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/menu/RadioButtonMenuGroup.kt
@@ -43,6 +43,9 @@ import javax.swing.KeyStroke
  * @see javax.swing.ButtonGroup
  */
 @Composable
+// Every option declares a chain of its own through the scope, so the group has no single item a
+// modifier of its own could reach.
+@Suppress("ModifierMissing")
 public fun RadioButtonMenuGroup(
     selectedIndex: Int,
     onSelectionChange: (Int) -> Unit,

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/CellStampComposition.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/CellStampComposition.kt
@@ -120,6 +120,7 @@ internal class CellStampComposition(
  * root of `setContent`, so the composition state a stamp writes invalidates this scope alone and the
  * synchronous recompose re-runs exactly it.
  */
+@Suppress("StateParam")
 @Composable
 private fun Stamp(
     hasCell: State<Boolean>,

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ComposingListCellRenderer.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ComposingListCellRenderer.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
@@ -164,6 +165,7 @@ internal class ComposingListCellRenderer<T>(
  * stamp names an item, so [itemState] always holds that item here - itself `null` among the values an
  * item can hold.
  */
+@Suppress("StateParam")
 @Composable
 private fun <T> Cell(
     itemState: State<Any?>,
@@ -179,7 +181,7 @@ private fun <T> Cell(
 
 /** The mutable backing of [ListItemScope]; its fields are written once per stamp. */
 private class MutableListItemScope : ListItemScope {
-    override var index: Int by mutableStateOf(-1)
+    override var index: Int by mutableIntStateOf(-1)
     override var isSelected: Boolean by mutableStateOf(false)
     override var cellHasFocus: Boolean by mutableStateOf(false)
 }

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ComposingTableCellRenderer.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ComposingTableCellRenderer.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
@@ -117,6 +118,7 @@ internal class ComposingTableCellRenderer<R>(
  * a row can hold. A column that declares no cell body composes nothing regardless: that one is about the
  * declaration, not the row.
  */
+@Suppress("StateParam")
 @Composable
 private fun <R> TableCell(
     rowState: State<R?>,
@@ -132,8 +134,8 @@ private fun <R> TableCell(
 
 /** The mutable backing of [TableCellScope]; its fields are written once per stamp. */
 private class MutableTableCellScope : TableCellScope {
-    override var rowIndex: Int by mutableStateOf(-1)
-    override var columnIndex: Int by mutableStateOf(-1)
+    override var rowIndex: Int by mutableIntStateOf(-1)
+    override var columnIndex: Int by mutableIntStateOf(-1)
     override var isSelected: Boolean by mutableStateOf(false)
     override var hasFocus: Boolean by mutableStateOf(false)
 }

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ComposingTreeCellRenderer.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/ComposingTreeCellRenderer.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
@@ -152,6 +153,7 @@ internal class ComposingTreeCellRenderer<T>(
  * stamp names a node, so [valueState] always holds that node's value here - itself `null` among the
  * values a node can hold.
  */
+@Suppress("StateParam")
 @Composable
 private fun <T> TreeNodeCell(
     valueState: State<T?>,
@@ -165,7 +167,7 @@ private fun <T> TreeNodeCell(
 
 /** The mutable backing of [TreeNodeScope]; its fields are written once per stamp. */
 private class MutableTreeNodeScope : TreeNodeScope {
-    override var row: Int by mutableStateOf(-1)
+    override var row: Int by mutableIntStateOf(-1)
     override var isSelected: Boolean by mutableStateOf(false)
     override var isExpanded: Boolean by mutableStateOf(false)
     override var isLeaf: Boolean by mutableStateOf(false)

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/Tree.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/components/selection/Tree.kt
@@ -812,6 +812,9 @@ private class TreeContentElement(
 
     override val additive: Boolean get() = true
 
+    /** [due] is a token standing for a change, not something a reader declared, so it is left out. */
+    override val declaredValues: Map<String, Any?> get() = mapOf("content" to content)
+
     /** The model and the selection the tree stands on are content the next declaration replaces. */
     override val restores: RestorePolicy get() = RestorePolicy.None
 

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/tooling/ComponentInspection.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/tooling/ComponentInspection.kt
@@ -151,8 +151,11 @@ private fun InspectedEffect(host: JComponent) {
     // would throw away everything recorded so far and leave a trace naming no file. The one time it is
     // asked again is when this call stands afresh after the switch went off and on, and the content it
     // records for is re-inserted on that same pass.
-    remember { composer.collectParameterInformation() }
-    val data = composer.compositionData
+    val data =
+        remember {
+            composer.collectParameterInformation()
+            composer.compositionData
+        }
     DisposableEffect(Unit) {
         host.publishCompositionData(data)
         // Only this composition's own publication is withdrawn, so a teardown can never blind a live

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/util/Key.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/util/Key.kt
@@ -23,7 +23,7 @@ import javax.swing.JComponent
  * keys sharing a [name] are two slots.
  */
 internal class Key<T>(
-    @NonNls val name: String,
+    @param:NonNls val name: String,
 ) {
     /** The property name a write fires under: `putClientProperty` names the event `key.toString()`. */
     override fun toString(): String = name

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/CompositionLocals.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/CompositionLocals.kt
@@ -61,6 +61,7 @@ internal val LocalProvidableWindow: ProvidableCompositionLocal<Window?> = static
  * that already has a window stands under it from its first pass. It is observable, so a content
  * composition that inherited none reads the window its container reaches once it arrives there.
  */
+@Suppress("StateParam")
 @Composable
 @ComposableOpenTarget(-1)
 internal fun ProvideContentLocals(
@@ -94,6 +95,7 @@ internal fun ProvideContentLocals(
  *
  * A caller wanting another [LocalLifecycleOwner] inside such a window provides one within its content.
  */
+@Suppress("StateParam")
 @Composable
 @ComposableOpenTarget(-1)
 internal fun ProvideWindowLocals(

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/CompositionOwnedWindowHost.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/CompositionOwnedWindowHost.kt
@@ -89,8 +89,12 @@ internal fun CompositionOwnedWindowHost(
     setPosition: (WindowPosition) -> Unit,
     setSize: (width: Int, height: Int) -> Unit,
     appliedGeometry: AppliedGeometry,
+    // Installed once per peer; the remover it returns must tear down that same installation.
+    @Suppress("LambdaParameterInRestartableEffect")
     installExtras: () -> () -> Unit,
     applyExtras: () -> Unit,
+    // Disposes the peer that keys the effect, so the captured function and effect have the same lifetime.
+    @Suppress("LambdaParameterInRestartableEffect")
     disposePeer: () -> Unit,
     content: @Composable WindowScope.() -> Unit,
 ) {

--- a/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/Dialog.kt
+++ b/swing-ui/src/main/kotlin/org/jetbrains/compose/swing/window/Dialog.kt
@@ -10,6 +10,7 @@ import java.awt.Dialog
 import java.awt.Dimension
 import java.awt.Image
 import java.awt.Toolkit
+import java.awt.Window
 import javax.swing.JDialog
 import javax.swing.SwingUtilities
 import javax.swing.WindowConstants
@@ -87,7 +88,7 @@ import javax.swing.WindowConstants
 public fun Dialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
-    owner: java.awt.Window? = null,
+    owner: Window? = null,
     title: @Nls String = "",
     modality: Dialog.ModalityType = Dialog.ModalityType.MODELESS,
     visible: Boolean = true,

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/SpinnerEditorBehaviorTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/SpinnerEditorBehaviorTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.compose.swing.components
 import androidx.compose.runtime.ReusableContentHost
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
@@ -212,7 +213,7 @@ class SpinnerEditorBehaviorTest {
         var active by mutableStateOf(true)
         setContent {
             ReusableContentHost(active = active) {
-                var value by mutableStateOf<Number>(3)
+                var value by remember { mutableStateOf<Number>(3) }
                 Spinner(value = value, onValueChange = { value = it }) { Label("value $value") }
             }
         }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/layout/ScrollableDefaultsTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/layout/ScrollableDefaultsTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.compose.swing.modifier.layout.preferredSize
 import org.jetbrains.compose.swing.test.interaction.performMouseWheel
 import org.jetbrains.compose.swing.test.onNodeOfType
 import org.jetbrains.compose.swing.test.runComposeSwingTest
+import java.awt.Component
 import java.awt.Dimension
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -203,7 +204,7 @@ class ScrollableDefaultsTest {
     }
 
     /** A line of [view]'s own font, which is what the library's components scroll by. */
-    private fun lineOf(view: java.awt.Component): Int =
+    private fun lineOf(view: Component): Int =
         assertIs<JComponent>(view, "the content is the viewport's view as it stands").let {
             it.getFontMetrics(it.font).height
         }

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TableRowSortingTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/components/selection/TableRowSortingTest.kt
@@ -43,6 +43,12 @@ class TableRowSortingTest {
     private fun tableModel(vararg names: String): DefaultTableModel =
         DefaultTableModel(names.map { arrayOf<Any?>(it) }.toTypedArray(), arrayOf<Any?>("Name"))
 
+    private val byLengthDescending =
+        Comparator<Any?> { first, second -> (second as String).length - (first as String).length }
+
+    private val byNameAscending =
+        Comparator<Any?> { first, second -> (first as String).compareTo(second as String) }
+
     /** The names the table shows, top to bottom. */
     private fun JTable.shownNames(): List<Any?> = (0 until rowCount).map { getValueAt(it, 0) }
 
@@ -132,7 +138,7 @@ class TableRowSortingTest {
         awaitIdle()
         assertEquals(setOf(0, 1, 2), received.last(), "every row is selected to start with")
 
-        filter = RowFilter.regexFilter<TableModel, Int>("Ada", 0)
+        filter = RowFilter.regexFilter("Ada", 0)
         awaitIdle()
 
         assertEquals(listOf("Ada"), table.shownNames(), "only the rows the filter admits are shown")
@@ -164,7 +170,7 @@ class TableRowSortingTest {
 
         // A filter takes hidden rows out of the table's selection - the wrapper's own write. The rows it drops
         // are re-selected once the filter admits them again, and reach no callback.
-        filter = RowFilter.regexFilter<TableModel, Int>("Ada", 0)
+        filter = RowFilter.regexFilter("Ada", 0)
         awaitIdle()
         assertEquals(setOf(0), table.selectedModelRows(), "the row the filter hides has no screen row to hold")
 
@@ -229,7 +235,7 @@ class TableRowSortingTest {
         val table = onNodeOfType<JTable>().fetch()
         assertEquals(people.map { it.name }, table.shownNames(), "every row is shown before a filter is declared")
 
-        filter = RowFilter.regexFilter<TableModel, Int>("Ada", 0)
+        filter = RowFilter.regexFilter("Ada", 0)
         selection = setOf(1)
         awaitIdle()
 
@@ -381,14 +387,13 @@ class TableRowSortingTest {
 
     @Test
     fun aColumnsComparatorOrdersItsRows() = runComposeSwingTest {
-        val byLength = Comparator<Any?> { first, second -> (second as String).length - (first as String).length }
         setContent {
             Table(
                 rows = people,
                 sortable = true,
                 sortKeys = listOf(SortKey(0, SortOrder.ASCENDING)),
             ) {
-                column(header = "Name", comparator = byLength) { it.name }
+                column(header = "Name", comparator = byLengthDescending) { it.name }
                 column("Age") { it.age }
             }
         }
@@ -425,11 +430,10 @@ class TableRowSortingTest {
 
     @Test
     fun aColumnsComparatorSurvivesARebuildOfTheColumns() = runComposeSwingTest {
-        val byLength = Comparator<Any?> { first, second -> (second as String).length - (first as String).length }
         var header by mutableStateOf("Name")
         setContent {
             Table(rows = people, sortable = true, sortKeys = listOf(SortKey(0, SortOrder.ASCENDING))) {
-                column(header = header, comparator = byLength) { it.name }
+                column(header = header, comparator = byLengthDescending) { it.name }
             }
         }
 
@@ -532,7 +536,6 @@ class TableRowSortingTest {
     fun aColumnWhoseDeclaredComparatorIsHeldIsNotSortedAgainOnEveryPass() = runComposeSwingTest {
         // Held across passes: a comparator compared by identity has to be, for the pass that redeclares
         // it to leave the ordering alone.
-        val byName = Comparator<Any?> { first, second -> (first as String).compareTo(second as String) }
         var rowHeight by mutableStateOf(20)
         setContent {
             Table(
@@ -541,7 +544,7 @@ class TableRowSortingTest {
                 sortKeys = listOf(SortKey(0, SortOrder.ASCENDING)),
                 rowHeight = rowHeight,
             ) {
-                column("Name", comparator = byName) { it.name }
+                column("Name", comparator = byNameAscending) { it.name }
             }
         }
 
@@ -560,7 +563,6 @@ class TableRowSortingTest {
     @Test
     fun aShiftExtensionAfterAnUnrelatedPassRunsFromTheRowTheSelectionStartedOn() = runComposeSwingTest {
         val rows = List(10) { "row $it" }
-        val byName = Comparator<Any?> { first, second -> (first as String).compareTo(second as String) }
         var rowHeight by mutableStateOf(20)
         setContent {
             Table(
@@ -569,7 +571,7 @@ class TableRowSortingTest {
                 sortKeys = listOf(SortKey(0, SortOrder.ASCENDING)),
                 rowHeight = rowHeight,
             ) {
-                column("Name", comparator = byName) { it }
+                column("Name", comparator = byNameAscending) { it }
             }
         }
 

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/KeyTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/modifier/KeyTest.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JTextField
+import javax.swing.text.Caret
 import javax.swing.text.DefaultCaret
 import javax.swing.text.JTextComponent
 import kotlin.test.Test
@@ -290,7 +291,7 @@ class KeyTest {
         class Node(
             private val caret: DefaultCaret,
         ) : SwingModifier.Node<JTextComponent>() {
-            private var found: javax.swing.text.Caret? = null
+            private var found: Caret? = null
 
             override fun onAttach() {
                 found = component.caret

--- a/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/window/LocalWindowTest.kt
+++ b/swing-ui/src/test/kotlin/org/jetbrains/compose/swing/window/LocalWindowTest.kt
@@ -16,6 +16,7 @@ import org.jetbrains.compose.swing.test.runComposeSwingTest
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import java.awt.Container
 import java.awt.GraphicsEnvironment
+import java.awt.Window
 import javax.swing.JDialog
 import javax.swing.JFrame
 import javax.swing.JMenuBar
@@ -259,7 +260,7 @@ class LocalWindowTest {
         var composed: Boolean = false
             private set
 
-        var seen: java.awt.Window? = null
+        var seen: Window? = null
             private set
 
         @Composable


### PR DESCRIPTION
- update Kotlin to 2.4.20 while keeping published bytecode on JVM 11
- add `swing-ui-detekt` with PSI-based rules for modifier APIs, inspection data and comparator identity
- configure Compose rules and AndroidX runtime lint across the project
- fix reported declarations and document narrowly scoped suppressions
- add ABI, provider-loading and regression coverage for the rules

Internal repository rules remain hidden from the published API and documentation.